### PR TITLE
feat: 홈 내 테이블뷰 영역 RxDataSources animatedSection 방식 채택 및 초기 적용

### DIFF
--- a/MOUP/MOUP/Domain/Entities/OwnerWorkplaceCellInfo.swift
+++ b/MOUP/MOUP/Domain/Entities/OwnerWorkplaceCellInfo.swift
@@ -1,0 +1,23 @@
+//
+//  OwnerWorkplaceCellInfo.swift
+//  MOUP
+//
+//  Created by 송규섭 on 8/12/25.
+//
+
+import Foundation
+import Differentiator
+
+struct OwnerWorkplaceCellInfo {
+    let workplace: WorkplaceData
+}
+
+extension OwnerWorkplaceCellInfo: IdentifiableType, Equatable {
+    var identity: String {
+        return workplace.id
+    }
+
+    static func == (lhs: OwnerWorkplaceCellInfo, rhs: OwnerWorkplaceCellInfo) -> Bool {
+        return lhs.workplace.id == rhs.workplace.id
+    }
+}

--- a/MOUP/MOUP/Domain/Entities/WorkerWorkplaceCellInfo.swift
+++ b/MOUP/MOUP/Domain/Entities/WorkerWorkplaceCellInfo.swift
@@ -1,0 +1,23 @@
+//
+//  WorkerWorkplaceCellInfo.swift
+//  MOUP
+//
+//  Created by 송규섭 on 8/12/25.
+//
+
+import Foundation
+import Differentiator
+
+struct WorkerWorkplaceCellInfo {
+    let workplace: WorkplaceData
+}
+
+extension WorkerWorkplaceCellInfo: IdentifiableType, Equatable  {
+    var identity: String {
+        return workplace.id
+    }
+
+    static func == (lhs: WorkerWorkplaceCellInfo, rhs: WorkerWorkplaceCellInfo) -> Bool {
+        return lhs.workplace.id == rhs.workplace.id
+    }
+}

--- a/MOUP/MOUP/Domain/Entities/WorkplaceData.swift
+++ b/MOUP/MOUP/Domain/Entities/WorkplaceData.swift
@@ -7,6 +7,7 @@
 
 struct WorkplaceData {
     // 근무지 정보
+    let id: String
     let name: String
     let category: String
     

--- a/MOUP/MOUP/Presentation/Home/View/Cell/OwnerWorkplaceCell.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/OwnerWorkplaceCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class OwnerWorkplaceCell: UITableViewCell {
     // MARK: - Properties
-    private let identifier = "OwnerWorkplaceCell"
+    static let identifier = "OwnerWorkplaceCell"
 
     // MARK: - Initializer
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/MOUP/MOUP/Presentation/Home/View/Cell/WorkerWorkplaceCell.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/WorkerWorkplaceCell.swift
@@ -9,7 +9,13 @@ import UIKit
 
 class WorkerWorkplaceCell: UITableViewCell {
     // MARK: - Properties
-    private let identifier = "WorkerWorkplaceCell"
+    static let identifier = "WorkerWorkplaceCell"
+
+    // MARK: - UI Components
+    private let titleLabel = UILabel().then {
+        $0.font = .bodyMedium(16)
+        $0.textColor = .gray900
+    }
 
     // MARK: - Initializer
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -21,6 +27,16 @@ class WorkerWorkplaceCell: UITableViewCell {
     @available(*, unavailable, message: "storyboard is not supported.")
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented.")
+    }
+
+    // MARK: - Public Methods
+    func update(item: HomeSectionItem) {
+        switch item {
+        case .worker(let workerInfo):
+            self.titleLabel.text = workerInfo.workplace.name
+        case .owner:
+            break
+        }
     }
 }
 
@@ -34,16 +50,18 @@ private extension WorkerWorkplaceCell {
 
     // MARK: - setHierarchy
     func setHierarchy() {
-
+        addSubviews(titleLabel)
     }
 
     // MARK: - setStyles
     func setStyles() {
-
+        
     }
 
     // MARK: - setConstraints
     func setConstraints() {
-
+        titleLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
     }
 }

--- a/MOUP/MOUP/Presentation/Home/View/HomeTableViewFirstSection.swift
+++ b/MOUP/MOUP/Presentation/Home/View/HomeTableViewFirstSection.swift
@@ -1,0 +1,39 @@
+//
+//  HomeTableViewFirstSection.swift
+//  MOUP
+//
+//  Created by 송규섭 on 8/12/25.
+//
+
+import Foundation
+import RxDataSources
+
+enum HomeSectionItem: Equatable, IdentifiableType {
+    case worker(WorkerWorkplaceCellInfo)
+    case owner(OwnerWorkplaceCellInfo)
+
+    var identity: String {
+        switch self {
+        case .worker(let info):
+            return info.identity
+        case .owner(let info):
+            return info.identity
+        }
+    }
+}
+
+struct HomeTableViewFirstSection {
+    let identity: Int
+    var header: String
+    var items: [Item]
+}
+
+extension HomeTableViewFirstSection: AnimatableSectionModelType {
+    typealias Item = HomeSectionItem
+    typealias Identity = Int
+
+    init(original: HomeTableViewFirstSection, items: [Item]) {
+        self = original
+        self.items = items
+    }
+}

--- a/MOUP/MOUP/Presentation/Home/View/HomeView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/HomeView.swift
@@ -8,6 +8,7 @@
 import UIKit
 import RxSwift
 import RxCocoa
+import RxDataSources
 
 final class HomeView: UIView {
     // MARK: - Properties
@@ -28,10 +29,12 @@ final class HomeView: UIView {
     }
 
     fileprivate let tableHeaderView = HomeHeaderContainerView(userRole: .worker) // TODO: - 실제 받아온 userRole 반영 필요
-    private lazy var tableView = UITableView().then {
+    fileprivate lazy var tableView = UITableView().then {
         $0.backgroundColor = .white
         $0.estimatedRowHeight = 300
         $0.rowHeight = UITableView.automaticDimension
+        $0.register(WorkerWorkplaceCell.self, forCellReuseIdentifier: WorkerWorkplaceCell.identifier)
+        $0.register(OwnerWorkplaceCell.self, forCellReuseIdentifier: OwnerWorkplaceCell.identifier)
     }
 
     // MARK: - Initializer
@@ -54,6 +57,12 @@ final class HomeView: UIView {
     }
 
     // MARK: - Public Methods
+    func setupTableView(
+        section: Observable<[HomeTableViewFirstSection]>,
+        dataSource: RxTableViewSectionedAnimatedDataSource<HomeTableViewFirstSection>
+    ) -> Disposable {
+        return section.bind(to: tableView.rx.items(dataSource: dataSource))
+    }
 }
 
 private extension HomeView {

--- a/MOUP/MOUP/Presentation/Home/ViewController/HomeViewController.swift
+++ b/MOUP/MOUP/Presentation/Home/ViewController/HomeViewController.swift
@@ -7,12 +7,22 @@
 
 import UIKit
 import RxSwift
+import RxDataSources
 
 final class HomeViewController: UIViewController {
+    // MARK: - Properties
     weak var coordinator: HomeCoordinator?
     private let homeViewModel: HomeViewModel
     private let homeView = HomeView()
     private let disposeBag = DisposeBag()
+
+    private lazy var dataSource = RxTableViewSectionedAnimatedDataSource<HomeTableViewFirstSection>(animationConfiguration: AnimationConfiguration(deleteAnimation: .automatic)) { dataSource, tableView, indexPath, item in
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: WorkerWorkplaceCell.identifier, for: indexPath) as? WorkerWorkplaceCell else {
+            return UITableViewCell()
+        }
+        cell.update(item: item)
+        return cell
+    }
 
 
     // MARK: - loadView
@@ -52,6 +62,9 @@ private extension HomeViewController {
     }
 
     func setBindings() {
+        let input = HomeViewModel.Input(viewDidLoad: Observable.just(()))
+        let output = homeViewModel.transform(input: input)
+
         homeView.rx.todayRoutineCardTap.subscribe(onNext: {
             print("오늘의 루틴 탭")
         })
@@ -66,5 +79,8 @@ private extension HomeViewController {
             print("플러스 버튼 탭")
         })
         .disposed(by: disposeBag)
+
+        homeView.setupTableView(section: output.firstSectionData, dataSource: dataSource)
+            .disposed(by: disposeBag)
     }
 }

--- a/MOUP/MOUP/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/MOUP/MOUP/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -6,7 +6,41 @@
 //
 
 import Foundation
+import RxSwift
+import RxRelay
 
 final class HomeViewModel {
-    
+    // MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private let mockFirstSectionDataRelay = BehaviorRelay<[HomeTableViewFirstSection]>(
+        value: [HomeTableViewFirstSection(identity: 0, header: "", items: [])]
+    ) // TODO: - nil을 허용할지 실제 백엔드 데이터 및 구조 확립 후 개선 필요
+
+    private let mockFirstSectionData = [HomeTableViewFirstSection(identity: 0, header: "", items: [
+        HomeSectionItem.worker(WorkerWorkplaceCellInfo(workplace: WorkplaceData(id: "0", name: "세븐일레븐 성남시청점", category: "편의점", payType: "매월", payCalculation: "시급", salary: "10300", payDay: "3", nationalPension: true, healthInsurance: true, employmentInsurance: true, industrialAccidentInsurance: true, incomeTax: false, weeklyHolidayAllowance: true, nightShiftAllowance: true, colorLabel: "빨간색"))),
+        HomeSectionItem.worker(WorkerWorkplaceCellInfo(workplace: WorkplaceData(id: "1", name: "이마트24 수진점", category: "편의점", payType: "매월", payCalculation: "시급", salary: "10300", payDay: "3", nationalPension: true, healthInsurance: true, employmentInsurance: true, industrialAccidentInsurance: true, incomeTax: false, weeklyHolidayAllowance: true, nightShiftAllowance: false, colorLabel: "빨간색")))
+    ])]
+
+    // MARK: - Input, Output
+    struct Input {
+        var viewDidLoad: Observable<Void>
+    }
+
+    struct Output {
+        var firstSectionData: Observable<[HomeTableViewFirstSection]>
+    }
+
+    // MARK: - transform
+    func transform(input: Input) -> Output {
+        input.viewDidLoad.subscribe(onNext: { [weak self] in
+            guard let self else { return }
+            mockFirstSectionDataRelay.accept(mockFirstSectionData)
+        })
+        .disposed(by: disposeBag)
+
+        return Output(
+            firstSectionData: mockFirstSectionDataRelay.asObservable()
+        )
+    }
+
 }

--- a/MOUP/MOUP/Presentation/WorkplaceRegister/ViewModel/WorkplaceRegisterViewModel.swift
+++ b/MOUP/MOUP/Presentation/WorkplaceRegister/ViewModel/WorkplaceRegisterViewModel.swift
@@ -85,6 +85,7 @@ final class WorkplaceRegisterViewModel: WorkplaceRegisterViewModelInput, Workpla
                 ) = second
 
                 return WorkplaceData(
+                    id: "0", // TODO: - 없던 버전으로 바꾸기
                     name: name,
                     category: category,
                     payType: payType,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #7 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- RxDataSources의 animatedSection을 사용하기 위해 필요한 데이터 모델에 프로토콜 적용
- 해당 모델들을 이용해 Section 구조 적용
- 테이블뷰에 해당 구조 적용 및 데이터 바인딩을 위한 목데이터 임시 적용
- 데이터 모델에 Equatable, IdentifiableType 적용으로 인해 WorkplaceData에 식별자용 id 프로퍼티 추가

WorkplaceData 내에 id를 임시로 추가해두었는데 만약 백엔드분과 말씀 나눠보고 id까지 받게 된다하면 해당 구조를 채택해도 좋을 듯 합니다. 
원식님 코드를 임시로 제가 추가한 필드 부분만 하드하게 적용해두었는데 따로 전달드렸고 이 점 또한 피드백 후에 빠르게 적용해보겠습니다 :)

<br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| IMG | <img src = "https://github.com/user-attachments/assets/5491f2f9-ff13-4830-bf66-b09f16ab4a8d" width ="250"> |

<br>
