### PR TITLE
feat: 홈 내 확장 및 축소 가능한 알바생 근무지 셀 초기 구현

### DIFF
--- a/MOUP/MOUP/Presentation/Home/View/Cell/OwnerWorkplaceCell.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/OwnerWorkplaceCell.swift
@@ -6,6 +6,10 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
+import SnapKit
+import Then
 
 class OwnerWorkplaceCell: UITableViewCell {
     // MARK: - Properties

--- a/MOUP/MOUP/Presentation/Home/View/Cell/SalaryDetailView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/SalaryDetailView.swift
@@ -1,0 +1,53 @@
+//
+//  SalaryDetailView.swift
+//  MOUP
+//
+//  Created by 송규섭 on 8/13/25.
+//
+
+import UIKit
+
+final class SalaryDetailView: UIView {
+    // MARK: - Properties
+
+    // MARK: - UI Components
+
+    // MARK: - Initializer
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        configure()
+    }
+
+    @available(*, unavailable, message: "storyboard is not supported.")
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented.")
+    }
+
+    // MARK: - Public Methods
+}
+
+private extension SalaryDetailView {
+    // MARK: - configure
+    func configure() {
+        setHierarchy()
+        setStyles()
+        setConstraints()
+    }
+
+    // MARK: - setHierarchy
+    func setHierarchy() {
+
+    }
+
+    // MARK: - setStyles
+    func setStyles() {
+
+    }
+
+    // MARK: - setConstraints
+    func setConstraints() {
+
+    }
+}
+

--- a/MOUP/MOUP/Presentation/Home/View/Cell/WorkerWorkplaceCell.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/WorkerWorkplaceCell.swift
@@ -6,15 +6,61 @@
 //
 
 import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
 
 class WorkerWorkplaceCell: UITableViewCell {
     // MARK: - Properties
     static let identifier = "WorkerWorkplaceCell"
+    private let disposeBag = DisposeBag()
+    private var isExpanded: Bool = false
+    private var dummyHeightConstraint: Constraint?
 
     // MARK: - UI Components
-    private let titleLabel = UILabel().then {
+    private let containerView = CardButton()
+    private let stackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.distribution = .fill
+        $0.spacing = 8
+        $0.isUserInteractionEnabled = false
+    }
+
+    // 첫 번째 섹션 뷰 - 기초 정보
+    private let firstSectionView = UIView()
+
+    private let nameLabel = UILabel().then {
         $0.font = .bodyMedium(16)
         $0.textColor = .gray900
+    }
+
+    private let untilPaydayLabel = UILabel().then {
+        $0.font = .bodyMedium(12)
+        $0.textColor = .gray700
+    }
+
+    fileprivate let menuButton = UIButton().then {
+        var config = UIButton.Configuration.plain()
+        config.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5)
+        config.image = .ellipsisButton
+        $0.configuration = config
+    }
+
+    private let totalEarnedLabel = UILabel().then {
+        $0.font = .bodyMedium(14)
+        $0.textColor = .gray900
+    }
+
+    // 두 번째 섹션 뷰 - 가변 급여 상세 테이블
+    private let secondSectionView = UIView()
+    private let dummyView = UIView().then {
+        $0.backgroundColor = .yellow
+    }
+
+    // 세 번째 섹션 뷰 - 출퇴근 버튼
+    private let thirdSectionView = UIView()
+    private let chevronImageView = UIImageView().then {
+        $0.image = .chevronDown
     }
 
     // MARK: - Initializer
@@ -29,11 +75,20 @@ class WorkerWorkplaceCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented.")
     }
 
+    // MARK: - prepareForReuse
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        isExpanded = false
+        dummyHeightConstraint?.update(offset: 0)
+    }
+
     // MARK: - Public Methods
     func update(item: HomeSectionItem) {
         switch item {
         case .worker(let workerInfo):
-            self.titleLabel.text = workerInfo.workplace.name
+            self.nameLabel.text = workerInfo.workplace.name
+            self.untilPaydayLabel.text = "sdfdfs"
+            self.totalEarnedLabel.text = "dsfdsf"
         case .owner:
             break
         }
@@ -44,24 +99,115 @@ private extension WorkerWorkplaceCell {
     // MARK: - configure
     func configure() {
         setHierarchy()
-        setStyles()
         setConstraints()
+        setStyles()
+        setBindings()
     }
 
     // MARK: - setHierarchy
     func setHierarchy() {
-        addSubviews(titleLabel)
+        contentView.addSubviews(containerView)
+        containerView.addSubviews(
+            stackView,
+            menuButton
+        )
+        firstSectionView.addSubviews(
+            nameLabel,
+            untilPaydayLabel,
+            totalEarnedLabel
+        )
+        secondSectionView.addSubviews(
+            dummyView
+        )
+        thirdSectionView.addSubviews(
+            chevronImageView
+        )
+        stackView.addArrangedSubviews(
+            firstSectionView,
+            secondSectionView,
+            thirdSectionView
+        )
     }
 
     // MARK: - setStyles
     func setStyles() {
-        
+        stackView.layer.cornerRadius = 12
     }
 
     // MARK: - setConstraints
     func setConstraints() {
-        titleLabel.snp.makeConstraints {
-            $0.center.equalToSuperview()
+        containerView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(12)
+            $0.directionalHorizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().inset(12)
+        }
+
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        // 첫 번째 섹션
+        nameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(12)
+            $0.leading.equalToSuperview().inset(16)
+        }
+
+        untilPaydayLabel.snp.makeConstraints {
+            $0.top.equalTo(nameLabel.snp.bottom)
+            $0.leading.equalToSuperview().inset(16)
+        }
+
+        menuButton.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(6)
+            $0.size.equalTo(44)
+        }
+
+        totalEarnedLabel.snp.makeConstraints {
+            $0.top.equalTo(menuButton.snp.bottom).offset(10)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview()
+        }
+
+        // 두 번째 섹션
+        dummyView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            dummyHeightConstraint = $0.height.equalTo(0).priority(.medium).constraint
+        }
+
+        // 세 번째 섹션
+        chevronImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(12)
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(8)
+            $0.width.equalTo(22)
+            $0.height.equalTo(16)
+        }
+    }
+
+    func setBindings() {
+        containerView.rx.tap.subscribe(onNext: { [weak self] in
+            guard let self else { return }
+            isExpanded.toggle()
+            toggleSecondSection(isExpanded)
+            print("containerView tapped")
+        })
+        .disposed(by: disposeBag)
+
+        menuButton.rx.tap.subscribe(onNext: {
+            print("메뉴버튼탭")
+        })
+        .disposed(by: disposeBag)
+    }
+
+    func toggleSecondSection(_ expanded: Bool) {
+        self.dummyHeightConstraint?.update(offset: expanded ? 200 : 0)
+        if let tableView = self.superview as? UITableView {
+            tableView.beginUpdates()
+            self.contentView.layoutIfNeeded()
+            tableView.endUpdates()
         }
     }
 }
+
+

--- a/MOUP/MOUP/Presentation/Home/View/Cell/WorkerWorkplaceCell.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/WorkerWorkplaceCell.swift
@@ -6,9 +6,10 @@
 //
 
 import UIKit
-import SnapKit
 import RxSwift
 import RxCocoa
+import SnapKit
+import Then
 
 class WorkerWorkplaceCell: UITableViewCell {
     // MARK: - Properties

--- a/MOUP/MOUP/Presentation/Home/View/HomeView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/HomeView.swift
@@ -29,12 +29,15 @@ final class HomeView: UIView {
     }
 
     fileprivate let tableHeaderView = HomeHeaderContainerView(userRole: .worker) // TODO: - 실제 받아온 userRole 반영 필요
+
     fileprivate lazy var tableView = UITableView().then {
         $0.backgroundColor = .white
-        $0.estimatedRowHeight = 300
+        $0.estimatedRowHeight = 400
         $0.rowHeight = UITableView.automaticDimension
         $0.register(WorkerWorkplaceCell.self, forCellReuseIdentifier: WorkerWorkplaceCell.identifier)
         $0.register(OwnerWorkplaceCell.self, forCellReuseIdentifier: OwnerWorkplaceCell.identifier)
+        $0.separatorStyle = .none
+        $0.allowsSelection = false
     }
 
     // MARK: - Initializer
@@ -107,7 +110,8 @@ private extension HomeView {
 
         tableView.snp.makeConstraints {
             $0.top.equalTo(topBar.snp.bottom)
-            $0.directionalHorizontalEdges.bottom.equalToSuperview()
+            $0.directionalHorizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide).inset(20)
         }
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #7 

<br>

## 📝 작업 내용
- 알바생이 홈에서 볼 수 있는 근무지 셀을 만들었습니다.
- 급여 상세 표는 우선 임시로 UIView로 채워서 셀의 확장 및 축소 기능을 구현했습니다.
- expandable한 셀을 구현하는 방식을 UIView 내 하위 컴포넌트들의 제약조건 활성화 토글을 통한 방식에서 UIStackView 기반으로 내부 UI 요소들을 세개의 섹션으로 쪼개 가변적인 뷰를 보다 더 보기 좋게 보여주고 숨길 수 있도록 구현했습니다. 이로서 기존 방식의 부자연스러운 확장 애니메이션이 해결된 것 같습니다.

<br>

## 📸 스크린샷
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 기존 | <img src = "https://github.com/user-attachments/assets/1f0a4b19-5387-42e6-97c8-2e9e8abf3900" width ="250"> |
| 현재 | <img src = "https://github.com/user-attachments/assets/873bf897-8268-469d-87ad-aa14fa563c1a" width ="250"> |

<br>
