### PR TITLE
feat: 홈 알바생 기준 근무지 셀 내에 상세 급여 테이블 등 추가해 기초 UI 보완

### DIFF
--- a/MOUP/MOUP/Presentation/Components/BaseButton.swift
+++ b/MOUP/MOUP/Presentation/Components/BaseButton.swift
@@ -11,9 +11,9 @@ import UIKit
 final class BaseButton: UIButton {
     
     // MARK: - Initializer
-    init(title: String = "적용하기", isSecondary: Bool = false) {
+    init(title: String = "적용하기", isSecondary: Bool = false, fontSize: CGFloat = 18) {
         super.init(frame: .zero)
-        configure(title: title, isSecondary: isSecondary)
+        configure(title: title, isSecondary: isSecondary, fontSize: fontSize)
     }
     
     @available(*, unavailable, message: "storyboard is not supported.")
@@ -22,32 +22,32 @@ final class BaseButton: UIButton {
     }
     
     // MARK: - Methods
-    func update(title: String, isSecondary: Bool = false) {
-        setConfiguration(title: title, isSecondary: isSecondary)
+    func update(title: String, isSecondary: Bool = false, fontSize: CGFloat = 18) {
+        setConfiguration(title: title, isSecondary: isSecondary, fontSize: fontSize)
     }
 }
 
 private extension BaseButton {
     // MARK: - configure
-    func configure(title: String, isSecondary: Bool) {
-        setStyles(title: title, isSecondary: isSecondary)
+    func configure(title: String, isSecondary: Bool, fontSize: CGFloat = 18) {
+        setStyles(title: title, isSecondary: isSecondary, fontSize: fontSize)
     }
     
     // MARK: - setStyles
-    func setStyles(title: String, isSecondary: Bool) {
-        setConfiguration(title: title, isSecondary: isSecondary)
-        
+    func setStyles(title: String, isSecondary: Bool, fontSize: CGFloat = 18) {
+        setConfiguration(title: title, isSecondary: isSecondary, fontSize: fontSize)
+
         self.clipsToBounds = true
         self.layer.cornerRadius = 12
     }
     
     // MARK: - setConfiguration
-    func setConfiguration(title: String, isSecondary: Bool) {
+    func setConfiguration(title: String, isSecondary: Bool, fontSize: CGFloat) {
         var config = UIButton.Configuration.filled()
         
-        let normalAttribute = AttributeContainer([.font: UIFont.buttonSemibold(18),
+        let normalAttribute = AttributeContainer([.font: UIFont.buttonSemibold(fontSize),
                                                   .foregroundColor: isSecondary ? UIColor.gray600 : UIColor.white])
-        let disableAttribute = AttributeContainer([.font: UIFont.buttonSemibold(18),
+        let disableAttribute = AttributeContainer([.font: UIFont.buttonSemibold(fontSize),
                                                    .foregroundColor: UIColor.gray500])
         let baseBackgroundColor: UIColor = isSecondary ? .gray200 : .accent
         config.attributedTitle = AttributedString(title, attributes: normalAttribute)

--- a/MOUP/MOUP/Presentation/Home/View/Cell/SalaryDetailRowView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/SalaryDetailRowView.swift
@@ -1,0 +1,129 @@
+//
+//  SalaryDetailRowView.swift
+//  MOUP
+//
+//  Created by 송규섭 on 8/18/25.
+//
+
+import UIKit
+
+final class SalaryDetailRowView: UIView {
+    // MARK: - Properties
+    private let title: String
+    private let time: String?
+    private let amount: Int? // TODO: - NumberFormatter 적용
+    private let showsBottomLine: Bool
+    private let isSection: Bool
+    private let showsTime: Bool
+
+    // MARK: - UI Components
+    private let titleLabel = UILabel().then {
+        $0.font = .bodyMedium(12)
+        $0.textColor = .gray900
+    }
+
+    private let timeLabel = UILabel().then {
+        $0.font = .bodyMedium(12)
+        $0.textColor = .gray900
+        $0.textAlignment = .right
+    }
+
+    private let amountLabel = UILabel().then {
+        $0.font = .bodyMedium(12)
+        $0.textColor = .gray900
+        $0.textAlignment = .right
+    }
+
+    private let bottomLine = UIView().then {
+        $0.backgroundColor = .gray300
+    }
+
+    // MARK: - Initializer
+    init(title: String, time: String?, amount: Int?, isSection: Bool, showsBottomLine: Bool, showsTime: Bool = true) {
+        self.title = title
+        self.time = time
+        self.amount = amount
+        self.isSection = isSection
+        self.showsBottomLine = showsBottomLine
+        self.showsTime = showsTime
+        super.init(frame: .zero)
+
+        configure()
+    }
+
+    @available(*, unavailable, message: "storyboard is not supported.")
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented.")
+    }
+
+    // MARK: - Public Methods
+}
+
+private extension SalaryDetailRowView {
+    // MARK: - configure
+    func configure() {
+        setHierarchy()
+        setStyles()
+        setConstraints()
+        applyData()
+    }
+
+    // MARK: - setHierarchy
+    func setHierarchy() {
+        addSubviews(
+            titleLabel,
+            timeLabel,
+            amountLabel,
+            bottomLine
+        )
+    }
+
+    // MARK: - setStyles
+    func setStyles() {
+        bottomLine.isHidden = !showsBottomLine
+        timeLabel.isHidden = !showsTime
+        if isSection {
+            [titleLabel, timeLabel, amountLabel].forEach {
+                $0.font = .headBold(12)
+            }
+            bottomLine.backgroundColor = .gray700
+        }
+    }
+
+    // MARK: - setConstraints
+    func setConstraints() {
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.directionalVerticalEdges.equalToSuperview().inset(4)
+        }
+
+        amountLabel.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+            $0.centerY.equalTo(titleLabel)
+            $0.width.equalTo(77.5)
+        }
+
+        timeLabel.snp.makeConstraints {
+            $0.trailing.equalTo(amountLabel.snp.leading).offset(-12)
+            $0.centerY.equalTo(titleLabel)
+            $0.width.equalTo(77.5)
+        }
+
+        bottomLine.snp.makeConstraints {
+            $0.directionalHorizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+    }
+
+    func applyData() {
+        titleLabel.text = title
+        timeLabel.text = time ?? "-"
+        if let amount {
+            amountLabel.text = NumberFormatter.formattedWon(from: String(amount))
+        } else {
+            amountLabel.text = "-"
+        }
+    }
+}
+

--- a/MOUP/MOUP/Presentation/Home/View/Cell/SalaryDetailView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/SalaryDetailView.swift
@@ -10,10 +10,9 @@ import SnapKit
 import Then
 
 final class SalaryDetailView: UIView {
+    // MARK: - Properties
+
     // MARK: - UI Components
-    private let stackView = UIStackView().then {
-        $0.axis = .vertical
-    }
     private var salaryDetailRows: [SalaryDetailRowView] = []
 
     // MARK: - Initializer
@@ -27,6 +26,8 @@ final class SalaryDetailView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented.")
     }
+
+    // MARK: - Public Methods
 }
 
 private extension SalaryDetailView {
@@ -40,24 +41,33 @@ private extension SalaryDetailView {
 
     // MARK: - setHierarchy
     func setHierarchy() {
-        addSubviews(stackView)
         salaryDetailRows.forEach {
-            stackView.addArrangedSubview($0)
+            addSubview($0)
         }
-
-        print("스택뷰의 개수: \(stackView.arrangedSubviews.count)")
     }
 
     // MARK: - setStyles
     func setStyles() {
-
+        backgroundColor = .clear
+        clipsToBounds = true
     }
 
     // MARK: - setConstraints
     func setConstraints() {
-        stackView.snp.makeConstraints {
-            $0.directionalVerticalEdges.equalToSuperview()
-            $0.directionalHorizontalEdges.equalToSuperview().inset(24)
+        for (index, row) in salaryDetailRows.enumerated() {
+            row.snp.makeConstraints {
+                $0.directionalHorizontalEdges.equalToSuperview().inset(24)
+
+                if index == 0 {
+                    $0.top.equalToSuperview()
+                } else {
+                    $0.top.equalTo(salaryDetailRows[index-1].snp.bottom)
+                }
+
+                if index == salaryDetailRows.count - 1 {
+                    $0.bottom.equalToSuperview()
+                }
+            }
         }
     }
 

--- a/MOUP/MOUP/Presentation/Home/View/Cell/SalaryDetailView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/SalaryDetailView.swift
@@ -6,11 +6,15 @@
 //
 
 import UIKit
+import SnapKit
+import Then
 
 final class SalaryDetailView: UIView {
-    // MARK: - Properties
-
     // MARK: - UI Components
+    private let stackView = UIStackView().then {
+        $0.axis = .vertical
+    }
+    private var salaryDetailRows: [SalaryDetailRowView] = []
 
     // MARK: - Initializer
     override init(frame: CGRect) {
@@ -23,13 +27,12 @@ final class SalaryDetailView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented.")
     }
-
-    // MARK: - Public Methods
 }
 
 private extension SalaryDetailView {
     // MARK: - configure
     func configure() {
+        setupRows()
         setHierarchy()
         setStyles()
         setConstraints()
@@ -37,7 +40,12 @@ private extension SalaryDetailView {
 
     // MARK: - setHierarchy
     func setHierarchy() {
+        addSubviews(stackView)
+        salaryDetailRows.forEach {
+            stackView.addArrangedSubview($0)
+        }
 
+        print("스택뷰의 개수: \(stackView.arrangedSubviews.count)")
     }
 
     // MARK: - setStyles
@@ -47,7 +55,24 @@ private extension SalaryDetailView {
 
     // MARK: - setConstraints
     func setConstraints() {
+        stackView.snp.makeConstraints {
+            $0.directionalVerticalEdges.equalToSuperview()
+            $0.directionalHorizontalEdges.equalToSuperview().inset(24)
+        }
+    }
 
+    // MARK: - setupRows
+    func setupRows() {
+        salaryDetailRows = [
+            .init(title: "총 근무", time: "25시간 07분", amount: 252000, isSection: true, showsBottomLine: true),
+            .init(title: "주간", time: "20시간 00분", amount: 200600, isSection: false, showsBottomLine: false),
+            .init(title: "야간", time: nil, amount: nil, isSection: false, showsBottomLine: true),
+            .init(title: "대타 근무", time: "05시간 07분", amount: 51344, isSection: true, showsBottomLine: false),
+            .init(title: "주간", time: "05시간 07분", amount: 51344, isSection: false, showsBottomLine: false),
+            .init(title: "야간", time: nil, amount: nil, isSection: false, showsBottomLine: true),
+            .init(title: "주휴 수당", time: nil, amount: nil, isSection: true, showsBottomLine: true),
+            .init(title: "4대 보험", time: nil, amount: 24947, isSection: true, showsBottomLine: false, showsTime: false),
+            .init(title: "소득세", time: nil, amount: 3528, isSection: true, showsBottomLine: false, showsTime: false)
+        ]
     }
 }
-

--- a/MOUP/MOUP/Presentation/Home/View/Cell/WorkerWorkplaceCell.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/WorkerWorkplaceCell.swift
@@ -56,6 +56,23 @@ class WorkerWorkplaceCell: UITableViewCell {
 
     // 세 번째 섹션 뷰 - 출퇴근 버튼
     private let thirdSectionView = UIView()
+
+    private let attendanceButtonStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 12
+    }
+
+    private let startWorkButton = BaseButton().then {
+        $0.update(title: "출근", isSecondary: false, fontSize: 16)
+    }
+
+    private let endWorkButton = BaseButton().then {
+        $0.update(title: "퇴근", isSecondary: true, fontSize: 16)
+    }
+
+    // 네 번째 섹션 뷰
+    private let fourthSectionView = UIView()
+
     private let chevronImageView = UIImageView().then {
         $0.image = .chevronDown
     }
@@ -113,14 +130,23 @@ private extension WorkerWorkplaceCell {
             untilPaydayLabel,
             totalEarnedLabel
         )
+        attendanceButtonStackView.addArrangedSubviews(
+            startWorkButton,
+            endWorkButton
+        )
         thirdSectionView.addSubviews(
+            attendanceButtonStackView
+        )
+        fourthSectionView.addSubviews(
             chevronImageView
         )
         stackView.addArrangedSubviews(
             firstSectionView,
             secondSectionView,
-            thirdSectionView
+            thirdSectionView,
+            fourthSectionView
         )
+
     }
 
     // MARK: - setStyles
@@ -145,11 +171,13 @@ private extension WorkerWorkplaceCell {
         nameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(12)
             $0.leading.equalToSuperview().inset(16)
+            $0.height.equalTo(24)
         }
 
         untilPaydayLabel.snp.makeConstraints {
             $0.top.equalTo(nameLabel.snp.bottom)
             $0.leading.equalToSuperview().inset(16)
+            $0.height.equalTo(18)
         }
 
         menuButton.snp.makeConstraints {
@@ -161,6 +189,7 @@ private extension WorkerWorkplaceCell {
         totalEarnedLabel.snp.makeConstraints {
             $0.top.equalTo(menuButton.snp.bottom).offset(10)
             $0.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(21)
             $0.bottom.equalToSuperview()
         }
 
@@ -170,6 +199,13 @@ private extension WorkerWorkplaceCell {
         }
 
         // 세 번째 섹션
+        attendanceButtonStackView.snp.makeConstraints {
+            $0.directionalVerticalEdges.equalToSuperview()
+            $0.directionalHorizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(44)
+        }
+
+        // 네 번째 섹션
         chevronImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(12)
             $0.centerX.equalToSuperview()

--- a/MOUP/MOUP/Presentation/Home/View/Cell/WorkerWorkplaceCell.swift
+++ b/MOUP/MOUP/Presentation/Home/View/Cell/WorkerWorkplaceCell.swift
@@ -16,7 +16,6 @@ class WorkerWorkplaceCell: UITableViewCell {
     static let identifier = "WorkerWorkplaceCell"
     private let disposeBag = DisposeBag()
     private var isExpanded: Bool = false
-    private var dummyHeightConstraint: Constraint?
 
     // MARK: - UI Components
     private let containerView = CardButton()
@@ -53,10 +52,7 @@ class WorkerWorkplaceCell: UITableViewCell {
     }
 
     // 두 번째 섹션 뷰 - 가변 급여 상세 테이블
-    private let secondSectionView = UIView()
-    private let dummyView = UIView().then {
-        $0.backgroundColor = .yellow
-    }
+    private let secondSectionView = SalaryDetailView()
 
     // 세 번째 섹션 뷰 - 출퇴근 버튼
     private let thirdSectionView = UIView()
@@ -80,7 +76,7 @@ class WorkerWorkplaceCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         isExpanded = false
-        dummyHeightConstraint?.update(offset: 0)
+        secondSectionView.isHidden = !isExpanded
     }
 
     // MARK: - Public Methods
@@ -117,9 +113,6 @@ private extension WorkerWorkplaceCell {
             untilPaydayLabel,
             totalEarnedLabel
         )
-        secondSectionView.addSubviews(
-            dummyView
-        )
         thirdSectionView.addSubviews(
             chevronImageView
         )
@@ -133,6 +126,7 @@ private extension WorkerWorkplaceCell {
     // MARK: - setStyles
     func setStyles() {
         stackView.layer.cornerRadius = 12
+        secondSectionView.isHidden = !isExpanded
     }
 
     // MARK: - setConstraints
@@ -140,7 +134,7 @@ private extension WorkerWorkplaceCell {
         containerView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(12)
             $0.directionalHorizontalEdges.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().inset(12)
+            $0.bottom.equalToSuperview().inset(12).priority(.medium)
         }
 
         stackView.snp.makeConstraints {
@@ -171,9 +165,8 @@ private extension WorkerWorkplaceCell {
         }
 
         // 두 번째 섹션
-        dummyView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-            dummyHeightConstraint = $0.height.equalTo(0).priority(.medium).constraint
+        secondSectionView.snp.makeConstraints {
+            $0.directionalHorizontalEdges.equalToSuperview()
         }
 
         // 세 번째 섹션
@@ -202,7 +195,8 @@ private extension WorkerWorkplaceCell {
     }
 
     func toggleSecondSection(_ expanded: Bool) {
-        self.dummyHeightConstraint?.update(offset: expanded ? 200 : 0)
+        self.secondSectionView.isHidden = !expanded
+
         if let tableView = self.superview as? UITableView {
             tableView.beginUpdates()
             self.contentView.layoutIfNeeded()


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #7 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 홈 알바생 근무지 셀 내에 급여 상세 명세서를 추가할 수 있게 구현했습니다.
- 가변 높이 셀을 위해 isHidden과 우선순위를 조합한 방식으로 기반을 변경했습니다.
- 임시로 출, 퇴근 버튼을 와이어프레임 상 디자인과 같게 구현해두었고, 조건에 따른 반응형 버튼은 이후에 구현 예정입니다.
- 출 퇴근 버튼이 공통 컴포넌트인 BaseButton을 쓰도록 구현되어있는데, 종종 내부 타이틀의 폰트 크기가 16인 점을 감안해 임시로 BaseButton 내에 폰트 크기도 반영할 수 있도록 구현했습니다. 피드백 주시면 수정해보도록 하겠습니다.

<br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/57cd3e48-b865-4f7f-a45e-4aa16ee08c17" width ="250"> |

<br>
