### PR TITLE
Feat/#49 루틴선택 화면에서 RxDataSources로 전환

### DIFF
--- a/MOUP/MOUP/Presentation/Routine/ViewController/RoutineSelectionViewController.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewController/RoutineSelectionViewController.swift
@@ -123,8 +123,6 @@ private extension RoutineSelectionViewController {
                     return UITableViewCell()
                 }
                 
-                cell.prepareForReuse()
-                
                 cell.update(with: viewState)
                 
                 cell.rx.checkboxDidTap

--- a/MOUP/MOUP/Presentation/Routine/ViewController/RoutineSelectionViewController.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewController/RoutineSelectionViewController.swift
@@ -8,11 +8,9 @@
 import UIKit
 import RxSwift
 import RxCocoa
+import RxDataSources
 
 final class RoutineSelectionViewController: UIViewController, UITableViewDelegate {
-    
-    typealias DataSource = UITableViewDiffableDataSource<Int, RoutineRowViewState>
-    typealias Snapshot = NSDiffableDataSourceSnapshot<Int, RoutineRowViewState>
     
     // MARK: - Properties
     
@@ -24,10 +22,6 @@ final class RoutineSelectionViewController: UIViewController, UITableViewDelegat
     private let addNewRoutineRelay = PublishRelay<Routine>()
     private let checkboxToggledRelay = PublishRelay<UUID>()
     private let routineUpdatedRelay = PublishRelay<Routine>()
-    
-    private lazy var dataSource = makeDataSource()
-    
-    private let latestRowsRelay = BehaviorRelay<[RoutineRowViewState]>(value: [])
     
     // MARK: - Lifecycle
     
@@ -58,7 +52,6 @@ private extension RoutineSelectionViewController {
     func configure() {
         setStyles()
         setTableView()
-        setDataSourceAndDelegate()
         setBindings()
     }
     
@@ -74,14 +67,10 @@ private extension RoutineSelectionViewController {
         )
     }
     
-    // MARK: - setDataSourceAndDelegate
-    func setDataSourceAndDelegate() {
-        routineSelectionView.tableView.dataSource = self.dataSource
-        routineSelectionView.tableView.delegate = self
-    }
-    
     // MARK: - setBindings
     func setBindings() {
+        let dataSource = createDataSource()
+        
         routineSelectionView.rx.plusButtonDidTap
             .bind(with: self) { owner, _ in
                 owner.coordinator?.showAddRoutineViewController(onSave: { newRoutine in
@@ -103,32 +92,15 @@ private extension RoutineSelectionViewController {
         let output = viewModel.transform(input)
         
         output.rows
-            .drive(onNext: { [weak self] rows in
-                self?.latestRowsRelay.accept(rows)
-                if let self,
-                   self.isViewLoaded,
-                   self.view.window != nil {
-                    self.applySnapshot(with: rows, animated: true)
-                }
-            })
+            .drive(routineSelectionView.tableView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
         
-        output.toggledRow
-            .emit(onNext: { [weak self] toggledState in
-                guard let self else { return }
-                var currentSnapshot = self.dataSource.snapshot()
-                currentSnapshot.reconfigureItems([toggledState])
-                self.dataSource.apply(currentSnapshot, animatingDifferences: false)
-            })
-            .disposed(by: disposeBag)
-        
-        routineSelectionView.rx.itemSelected
-            .compactMap { [weak self] indexPath in
-                self?.dataSource.itemIdentifier(for: indexPath)
-            }
+        routineSelectionView.tableView.rx.modelSelected(RoutineRowViewState.self)
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
             .bind(with: self) { owner, viewState in
-                owner.coordinator?.showEditRoutineViewController(routine: viewState.routine) { updated in
+                owner.coordinator?.showEditRoutineViewController(
+                    routine: viewState.routine
+                ) { updated in
                     owner.routineUpdatedRelay.accept(updated)
                 }
             }
@@ -137,42 +109,29 @@ private extension RoutineSelectionViewController {
         routineSelectionView.rx.itemSelected
             .bind(to: routineSelectionView.rx.deselectRow)
             .disposed(by: disposeBag)
-        
-        self.rx.sentMessage(#selector(UIViewController.viewWillAppear(_:)))
-            .map { _ in () }
-            .withLatestFrom(latestRowsRelay.asObservable())
-            .observe(on: MainScheduler.instance)
-            .bind(with: self) { owner, rows in
-                owner.applySnapshot(with: rows, animated: false)
-            }
-            .disposed(by: disposeBag)
     }
     
-    func makeDataSource() -> DataSource {
-        let dataSource = DataSource(
-            tableView: routineSelectionView.tableView
-        ) { [weak self] tableView, indexPath, viewState in
-            guard let self,
-                  let cell = tableView.dequeueReusableCell(withIdentifier: RoutineCell.id, for: indexPath) as? RoutineCell else {
-                return UITableViewCell()
+    func createDataSource() -> RxTableViewSectionedAnimatedDataSource<RoutineSectionModel> {
+        return RxTableViewSectionedAnimatedDataSource<RoutineSectionModel>(
+            configureCell: { [weak self] dataSource, tableView, indexPath, viewState in
+                guard let self,
+                      let cell = tableView.dequeueReusableCell(
+                        withIdentifier: RoutineCell.id,
+                        for: indexPath
+                      ) as? RoutineCell else {
+                    return UITableViewCell()
+                }
+                
+                cell.disposeBag = DisposeBag()
+                cell.update(with: viewState)
+                
+                cell.rx.checkboxDidTap
+                    .map { viewState.routine.id }
+                    .bind(to: self.checkboxToggledRelay)
+                    .disposed(by: cell.disposeBag)
+                
+                return cell
             }
-            
-            cell.disposeBag = DisposeBag()
-            cell.update(with: viewState)
-            cell.rx.checkboxDidTap
-                .map { viewState.routine.id }
-                .bind(to: self.checkboxToggledRelay)
-                .disposed(by: cell.disposeBag)
-            
-            return cell
-        }
-        return dataSource
-    }
-    
-    func applySnapshot(with rows: [RoutineRowViewState], animated: Bool) {
-        var snapshot = Snapshot()
-        snapshot.appendSections([0])
-        snapshot.appendItems(rows, toSection: 0)
-        dataSource.apply(snapshot, animatingDifferences: animated)
+        )
     }
 }

--- a/MOUP/MOUP/Presentation/Routine/ViewController/RoutineSelectionViewController.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewController/RoutineSelectionViewController.swift
@@ -10,7 +10,7 @@ import RxSwift
 import RxCocoa
 import RxDataSources
 
-final class RoutineSelectionViewController: UIViewController, UITableViewDelegate {
+final class RoutineSelectionViewController: UIViewController {
     
     // MARK: - Properties
     
@@ -114,15 +114,17 @@ private extension RoutineSelectionViewController {
     func createDataSource() -> RxTableViewSectionedAnimatedDataSource<RoutineSectionModel> {
         return RxTableViewSectionedAnimatedDataSource<RoutineSectionModel>(
             configureCell: { [weak self] dataSource, tableView, indexPath, viewState in
-                guard let self,
-                      let cell = tableView.dequeueReusableCell(
+                guard let self else { return UITableViewCell() }
+                guard let cell = tableView.dequeueReusableCell(
                         withIdentifier: RoutineCell.id,
                         for: indexPath
                       ) as? RoutineCell else {
+                    assertionFailure("RoutineCell dequeue 실패")
                     return UITableViewCell()
                 }
                 
-                cell.disposeBag = DisposeBag()
+                cell.prepareForReuse()
+                
                 cell.update(with: viewState)
                 
                 cell.rx.checkboxDidTap

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/RoutineSelectionViewModel.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/RoutineSelectionViewModel.swift
@@ -89,6 +89,7 @@ final class RoutineSelectionViewModel {
                 }
                 return [RoutineSectionModel(model: 0, items: viewStates)]
             }
+            .distinctUntilChanged()
             .asDriver(onErrorJustReturn: [])
         
         return Output(

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/RoutineSelectionViewModel.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/RoutineSelectionViewModel.swift
@@ -51,7 +51,8 @@ final class RoutineSelectionViewModel {
     
     func transform(_ input: Input) -> Output {
         let initialRoutines = input.appear
-            .flatMapLatest { [unowned self] _ -> Observable<[Routine]> in
+            .flatMapLatest { [weak self] _ -> Observable<[Routine]> in
+                guard let self else { return .empty() }
                 // TODO: usecase 호출
                 return .just(self.fetchDummyData())
             }

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/RoutineSelectionViewModel.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/RoutineSelectionViewModel.swift
@@ -8,19 +8,26 @@
 import Foundation
 import RxSwift
 import RxCocoa
+import RxDataSources
 
-struct RoutineRowViewState: Hashable {
+struct RoutineRowViewState: IdentifiableType, Hashable {
     let routine: Routine
     var isChecked: Bool
+    
+    var identity: UUID {
+        return routine.id
+    }
     
     func hash(into hasher: inout Hasher) {
         hasher.combine(routine.id)
     }
     
     static func == (lhs: RoutineRowViewState, rhs: RoutineRowViewState) -> Bool {
-        lhs.routine.id == rhs.routine.id
+        lhs.routine.id == rhs.routine.id && lhs.isChecked == rhs.isChecked
     }
 }
+
+typealias RoutineSectionModel = AnimatableSectionModel<Int, RoutineRowViewState>
 
 final class RoutineSelectionViewModel {
     struct Input {
@@ -31,8 +38,7 @@ final class RoutineSelectionViewModel {
     }
     
     struct Output {
-        let rows: Driver<[RoutineRowViewState]>
-        let toggledRow: Signal<RoutineRowViewState>
+        let rows: Driver<[RoutineSectionModel]>
     }
     
     // MARK: - Properties
@@ -44,8 +50,6 @@ final class RoutineSelectionViewModel {
     // MARK: - Transform
     
     func transform(_ input: Input) -> Output {
-        let toggledRowRelay = PublishRelay<RoutineRowViewState>()
-        
         let initialRoutines = input.appear
             .flatMapLatest { [unowned self] _ -> Observable<[Routine]> in
                 // TODO: usecase 호출
@@ -66,42 +70,28 @@ final class RoutineSelectionViewModel {
             .bind(to: routinesRelay)
             .disposed(by: disposeBag)
         
-        let checkboxToggleEvent = input.checkboxToggled
-            .withLatestFrom(checkedIDsRelay) { toggledID, currentIDs -> (toggledID: UUID, newIDs: Set<UUID>) in
-                let newCheckedIDs = currentIDs.symmetricDifference([toggledID])
-                return (toggledID, newCheckedIDs)
+        input.checkboxToggled
+            .withLatestFrom(checkedIDsRelay) { toggledID, currentIDs in
+                currentIDs.symmetricDifference([toggledID])
             }
-            .share()
-        
-        checkboxToggleEvent
-            .map { $0.newIDs }
             .bind(to: checkedIDsRelay)
-            .disposed(by: disposeBag)
-        
-        checkboxToggleEvent
-            .withLatestFrom(routinesRelay) { toggleInfo, routines -> RoutineRowViewState? in
-                guard let routine = routines.first(
-                    where: { $0.id == toggleInfo.toggledID }
-                ) else {
-                    return nil
-                }
-                let isChecked = toggleInfo.newIDs.contains(toggleInfo.toggledID)
-                return RoutineRowViewState(routine: routine, isChecked: isChecked)
-            }
-            .compactMap { $0 }
-            .bind(to: toggledRowRelay)
             .disposed(by: disposeBag)
         
         let rows = Observable
             .combineLatest(routinesRelay, checkedIDsRelay)
-            .map { routines, checked in
-                routines.map { RoutineRowViewState(routine: $0, isChecked: checked.contains($0.id)) }
+            .map { routines, checkedIDs -> [RoutineSectionModel] in
+                let viewStates = routines.map {
+                    RoutineRowViewState(
+                        routine: $0,
+                        isChecked: checkedIDs.contains($0.id)
+                    )
+                }
+                return [RoutineSectionModel(model: 0, items: viewStates)]
             }
             .asDriver(onErrorJustReturn: [])
         
         return Output(
-            rows: rows,
-            toggledRow: toggledRowRelay.asSignal()
+            rows: rows
         )
     }
     


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #49 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 루틴 선택 화면에서 기존 diffableDataSource로 구현되어 있던것을 RxDataSources로 전환했습니다.
