### PR TITLE
루틴 임시저장 기능 구현 완료

### DIFF
--- a/MOUP/MOUP/Data/Repositories/DraftRoutineStorage/DraftRoutineStorage.swift
+++ b/MOUP/MOUP/Data/Repositories/DraftRoutineStorage/DraftRoutineStorage.swift
@@ -1,0 +1,39 @@
+//
+//  DraftRoutineStorage.swift
+//  MOUP
+//
+//  Created by 신영 on 10/26/25.
+//
+
+import Foundation
+
+final class DraftRoutineStorage: DraftRoutineStorageProtocol {
+    static let shared = DraftRoutineStorage()
+    
+    private let key = "DraftRoutine"
+    private let userDefaults = UserDefaults.standard
+    
+    func saveDraft(_ routine: DraftRoutine) {
+        do {
+            let encoded = try JSONEncoder().encode(routine)
+            userDefaults.set(encoded, forKey: key)
+        } catch {
+            print("Draft 저장 실패: \(error)")
+        }
+    }
+    
+    func loadDraft() -> DraftRoutine? {
+        guard let data = userDefaults.data(forKey: key) else { return nil }
+        
+        do {
+            return try JSONDecoder().decode(DraftRoutine.self, from: data)
+        } catch {
+            print("Draft 로드 실패: \(error)")
+            return nil
+        }
+    }
+    
+    func deleteDraft() {
+        userDefaults.removeObject(forKey: key)
+    }
+}

--- a/MOUP/MOUP/Data/Repositories/DraftRoutineStorage/DraftRoutineStorageProtocol.swift
+++ b/MOUP/MOUP/Data/Repositories/DraftRoutineStorage/DraftRoutineStorageProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  DraftRoutineStorageProtocol.swift
+//  MOUP
+//
+//  Created by 신영 on 10/26/25.
+//
+
+import Foundation
+
+protocol DraftRoutineStorageProtocol {
+    func saveDraft(_ routine: DraftRoutine)
+    func loadDraft() -> DraftRoutine?
+    func deleteDraft()
+}

--- a/MOUP/MOUP/Domain/Entities/DraftRoutine.swift
+++ b/MOUP/MOUP/Domain/Entities/DraftRoutine.swift
@@ -1,0 +1,15 @@
+//
+//  DraftRoutine.swift
+//  MOUP
+//
+//  Created by 신영 on 10/26/25.
+//
+
+import Foundation
+
+struct DraftRoutine: Codable {
+    let title: String
+    let alarmTime: DateComponents?
+    let items: [TodoItem]
+    let savedAt: Date
+}

--- a/MOUP/MOUP/Domain/Entities/TodoItem.swift
+++ b/MOUP/MOUP/Domain/Entities/TodoItem.swift
@@ -7,9 +7,14 @@
 
 import Foundation
 
-struct TodoItem: Hashable {
-    let id: UUID = UUID()
+struct TodoItem: Hashable, Codable {
+    let id: UUID
     var text: String
+    
+    init(text: String) {
+        self.id = UUID()
+        self.text = text
+    }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)

--- a/MOUP/MOUP/Presentation/Components/DeleteAlertViewController.swift
+++ b/MOUP/MOUP/Presentation/Components/DeleteAlertViewController.swift
@@ -17,6 +17,7 @@ final class DeleteAlertViewController: UIViewController {
     private let alertTitle: String
     private let alertMessage: String
     var onDeleteConfirmed: (() -> Void)?
+    var onCancelConfirmed: (() -> Void)?
     private let disposeBag = DisposeBag()
     private let deleteButtonTitle: String
     
@@ -148,6 +149,7 @@ private extension DeleteAlertViewController {
     func setActions() {
         cancelButton.rx.tap
             .bind(with: self) { owner, _ in
+                owner.onCancelConfirmed?()
                 owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)

--- a/MOUP/MOUP/Presentation/Routine/View/AddRoutineView.swift
+++ b/MOUP/MOUP/Presentation/Routine/View/AddRoutineView.swift
@@ -107,6 +107,10 @@ final class AddRoutineView: UIView {
     
     // MARK: - Public Methods
     
+    func updateRoutineTitleLabel(with title: String) {
+        textfield.text = title
+    }
+    
     func updateAlarmTimeChip(with components: DateComponents) {
         guard let hour = components.hour, let minute = components.minute else {
             alarmTimeChipView.isHidden = true
@@ -135,6 +139,15 @@ final class AddRoutineView: UIView {
             x: alarmTimeButton.center.x + 5, y: alarmTimeButton.center.y
         ))
         alarmTimeButton.layer.add(animation, forKey: "position")
+    }
+    
+    func restoreItems(_ items: [TodoItem]) {
+        let validItems = items.isEmpty ? [TodoItem(text: "")] : items
+        
+        var snapshot = NSDiffableDataSourceSnapshot<Section, TodoItem>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(validItems, toSection: .main)
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 }
 

--- a/MOUP/MOUP/Presentation/Routine/ViewController/AddRoutineViewController.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewController/AddRoutineViewController.swift
@@ -96,13 +96,14 @@ private extension AddRoutineViewController {
         )
         
         let input = AddRoutineViewModel.Input(
-            titleChanged: addRoutineView.rx.titleText.orEmpty.asObservable(),
-            alarmTimeChanged: selectedTime.map { Optional($0) }.asObservable(),
+            titleChanged: titleChanged,
+            alarmTimeChanged: alarmTimeChanged,
             saveButtonTapped: addRoutineView.rx.saveButtonTap.asObservable(),
             addTodoButtonTapped: addRoutineView.rx.addButtonTap.asObservable(),
             itemTextChanged: addRoutineView.rx.itemTextChanged,
             itemMoved: addRoutineView.rx.itemMoved,
-            itemDeleted: addRoutineView.rx.itemDeleted
+            itemDeleted: addRoutineView.rx.itemDeleted,
+            itemsLoaded: itemsInputSubject.asObservable()
         )
         
         let output = viewModel.transform(input: input)
@@ -180,6 +181,10 @@ private extension AddRoutineViewController {
         
         if let alarmTime = draft.alarmTime {
             alarmTimeInputSubject.onNext(alarmTime)
+        }
+        
+        if !draft.items.isEmpty {
+            itemsInputSubject.onNext(draft.items)
         }
     }
 }

--- a/MOUP/MOUP/Presentation/Routine/ViewController/AddRoutineViewController.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewController/AddRoutineViewController.swift
@@ -17,6 +17,9 @@ final class AddRoutineViewController: UIViewController {
     private let viewModel: AddRoutineViewModel
     private let disposeBag = DisposeBag()
     var onSave: ((Routine) -> Void)?
+    private let titleInputSubject = PublishSubject<String>()
+    private let alarmTimeInputSubject = PublishSubject<DateComponents?>()
+    private let itemsInputSubject = PublishSubject<[TodoItem]>()
     
     // MARK: - Lifecycle
     
@@ -26,8 +29,9 @@ final class AddRoutineViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         configure()
+        checkAndPromptLoadDraft()
     }
     
     // MARK: - Initializer
@@ -81,6 +85,16 @@ private extension AddRoutineViewController {
             }
             .disposed(by: disposeBag)
         
+        let titleChanged = Observable.merge(
+            addRoutineView.rx.titleText.orEmpty.asObservable(),
+            titleInputSubject
+        )
+        
+        let alarmTimeChanged = Observable.merge(
+            selectedTime.map { Optional($0) }.asObservable(),
+            alarmTimeInputSubject.asObservable()
+        )
+        
         let input = AddRoutineViewModel.Input(
             titleChanged: addRoutineView.rx.titleText.orEmpty.asObservable(),
             alarmTimeChanged: selectedTime.map { Optional($0) }.asObservable(),
@@ -125,5 +139,47 @@ private extension AddRoutineViewController {
                 owner.navigationController?.popViewController(animated: true)
             })
             .disposed(by: disposeBag)
+    }
+    
+    func checkAndPromptLoadDraft() {
+        guard let draft = DraftRoutineStorage.shared.loadDraft() else { return }
+        
+        let alert = DeleteAlertViewController(
+            alertTitle: "저장된 루틴이 있습니다",
+            alertMessage: "이전에 저장한 내용을 불러올까요?",
+            deleteButtonTitle: "불러오기"
+        )
+        
+        alert.onDeleteConfirmed = { [weak self] in
+            self?.loadDraft(draft)
+        }
+        
+        alert.onCancelConfirmed = {
+            DraftRoutineStorage.shared.deleteDraft()
+        }
+        
+        present(alert, animated: false)
+    }
+    
+    func loadDraft(_ draft: DraftRoutine) {
+        if !draft.title.isEmpty {
+            addRoutineView.updateRoutineTitleLabel(with: draft.title)
+        }
+        
+        if let alarmTime = draft.alarmTime {
+            addRoutineView.updateAlarmTimeChip(with: alarmTime)
+        }
+        
+        if !draft.items.isEmpty {
+            addRoutineView.restoreItems(draft.items)
+        }
+        
+        if !draft.title.isEmpty {
+            titleInputSubject.onNext(draft.title)
+        }
+        
+        if let alarmTime = draft.alarmTime {
+            alarmTimeInputSubject.onNext(alarmTime)
+        }
     }
 }

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/AddRoutineViewModel.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/AddRoutineViewModel.swift
@@ -44,6 +44,13 @@ final class AddRoutineViewModel {
     // MARK: - Properties
     
     private let disposeBag = DisposeBag()
+    private let storage: DraftRoutineStorageProtocol
+    
+    // MARK: - Initializer
+    
+    init(storage: DraftRoutineStorageProtocol = DraftRoutineStorage.shared) {
+        self.storage = storage
+    }
     
     // MARK: - Transform
     
@@ -121,6 +128,28 @@ final class AddRoutineViewModel {
                 return newItems
             }
             .bind(to: itemsRelay)
+            .disposed(by: disposeBag)
+        
+        Observable.combineLatest(titleRelay, alarmTimeRelay, itemsRelay)
+            .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
+            .map { title, alarmTime, items in
+                DraftRoutine(
+                    title: title,
+                    alarmTime: alarmTime,
+                    items: items,
+                    savedAt: Date()
+                )
+            }
+            .withUnretained(self)
+            .subscribe(onNext: { owner, draft in
+                owner.storage.saveDraft(draft)
+            })
+            .disposed(by: disposeBag)
+        
+        saveCompletedRelay
+            .subscribe(onNext: { [weak self] _ in
+                self?.storage.deleteDraft()
+            })
             .disposed(by: disposeBag)
         
         input.saveButtonTapped

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/AddRoutineViewModel.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/AddRoutineViewModel.swift
@@ -28,6 +28,8 @@ final class AddRoutineViewModel {
         let itemTextChanged: Observable<(index: Int, text: String)>
         let itemMoved: Observable<(source: Int, destination: Int)>
         let itemDeleted: Observable<Int>
+        
+        let itemsLoaded: Observable<[TodoItem]>?
     }
     
     // MARK: - Output
@@ -70,6 +72,12 @@ final class AddRoutineViewModel {
         input.alarmTimeChanged
             .bind(to: alarmTimeRelay)
             .disposed(by: disposeBag)
+        
+        if let itemsLoaded = input.itemsLoaded {
+            itemsLoaded
+                .bind(to: itemsRelay)
+                .disposed(by: disposeBag)
+        }
         
         input.addTodoButtonTapped
             .withLatestFrom(itemsRelay)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #53 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 루틴 임시저장(Draft) 기능 구현
  - 제목, 알람 시간, 투두 아이템 변경 시 자동으로 500ms 디바운스 후 임시 저장
  - 저장 완료 후 임시저장 데이터 자동 삭제

<br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 루틴 폼 작성중 뒤로가기 |![화면 기록 2025-10-28 오후 11 05 10](https://github.com/user-attachments/assets/a6926a98-49f4-46ad-84a2-28721ac875aa)|
| 루틴 폼 작성중 뒤로가기2 |![화면 기록 2025-10-28 오후 11 05 49](https://github.com/user-attachments/assets/a67c1065-eca3-4eef-a38f-a848e90336cc)|
| 루틴 저장 완료 후 임시데이터 자동삭제 |![화면 기록 2025-10-28 오후 11 05 31](https://github.com/user-attachments/assets/317e3a30-ee48-419e-aac7-11deef05b22c)




<br>
