### PR TITLE
fix: Home 헤더 뷰에서 발생하던 버그 해결

### DIFF
--- a/MOUP/MOUP/Presentation/Home/View/HomeView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/HomeView.swift
@@ -15,6 +15,7 @@ import Then
 final class HomeView: UIView {
     // MARK: - Properties
     private let userRole: UserRole
+    private var isTableHeaderViewConfigured = false
     
     // MARK: - UI Components
     private let topBar = UIView()
@@ -60,7 +61,11 @@ final class HomeView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        
+        // viewDidLoad, init에서 호출 시 제약조건 충돌 발생으로 인해 플래그 사용
+        if !isTableHeaderViewConfigured && bounds.width > 0 {
+            setTableHeaderView()
+            isTableHeaderViewConfigured = true
+        }
     }
     
     // MARK: - Public Methods
@@ -82,7 +87,6 @@ private extension HomeView {
         setHierarchy()
         setStyles()
         setConstraints()
-        setTableHeaderView()
     }
     
     // MARK: - setHierarchy

--- a/MOUP/MOUP/Presentation/Home/View/HomeView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/HomeView.swift
@@ -132,7 +132,6 @@ private extension HomeView {
         // TODO: - 테이블뷰 셀 상단 영역 8을 그림자를 위해 남겨놨으니 설정 필요
         guard let rawValue = UserDefaultsManager.shared.userRole,
         let role = UserRole(rawValue: rawValue) else { return }
-        self.tableHeaderView = HomeHeaderContainerView(userRole: role)
         tableHeaderView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 332)
         tableView.tableHeaderView = tableHeaderView
     }

--- a/MOUP/MOUP/Presentation/Home/View/HomeView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/HomeView.swift
@@ -15,7 +15,7 @@ import Then
 final class HomeView: UIView {
     // MARK: - Properties
     private let userRole: UserRole
-    private var isTableHeaderViewConfigured = false
+    private var didConfigureTableHeaderView = false
     
     // MARK: - UI Components
     private let topBar = UIView()
@@ -62,9 +62,9 @@ final class HomeView: UIView {
         super.layoutSubviews()
         
         // viewDidLoad, init에서 호출 시 제약조건 충돌 발생으로 인해 플래그 사용
-        if !isTableHeaderViewConfigured && bounds.width > 0 {
+        if !didConfigureTableHeaderView && bounds.width > 0 {
             setTableHeaderView()
-            isTableHeaderViewConfigured = true
+            didConfigureTableHeaderView = true
         }
     }
     

--- a/MOUP/MOUP/Resources/Info.plist
+++ b/MOUP/MOUP/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>User Interface Style</key>
+	<string>Light</string>
 	<key>BaseURL</key>
 	<string>$(BASE_URL)</string>
 	<key>CFBundleIconName</key>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #60 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 홈 내 데이터들이 초기에 바인딩되었다가 시간이 좀 지나고 셀을 확장/축소하는 과정 속에서 초기화되는 버그 해결 (인스턴스 재할당 코드 제거)
- 홈 헤더 내 루틴 관련 페이지로 이동하는 버튼에 대한 액션이 실행되지 않는 버그 해결 (setTableHeaderView 내에 기존 헤더뷰에 대한 설정을 통해 해결)

<br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 홈 | <img src = "https://github.com/user-attachments/assets/c84a0751-8b5d-4400-82bc-2eca3bb78856" width ="250"> |

<br>
