### PR TITLE
feat: 오늘의 루틴 측 2 depth, 전체 루틴 페이지 데이터 바인딩 구현

### DIFF
--- a/MOUP/MOUP/Common/Utils/Extensions/UIViewController+Extension.swift
+++ b/MOUP/MOUP/Common/Utils/Extensions/UIViewController+Extension.swift
@@ -52,8 +52,8 @@ extension UIViewController {
         child.removeFromParent()
     }
     
-    func presentNoticeModal(title: String, comment: String) {
-        let vc = NoticeModalViewController(title: title, comment: comment)
+    func presentNoticeModal(title: String, comment: String, onConfirm: (() -> Void)? = nil) {
+        let vc = NoticeModalViewController(title: title, comment: comment, onConfirm: onConfirm)
         vc.modalPresentationStyle = .overFullScreen
         present(vc, animated: true)
     }

--- a/MOUP/MOUP/Coordinator/HomeCoordinator.swift
+++ b/MOUP/MOUP/Coordinator/HomeCoordinator.swift
@@ -12,12 +12,18 @@ final class HomeCoordinator: Coordinator {
     private let homeUseCase: HomeUseCaseProtocol
     private let homeRepository: HomeRepositoryProtocol
     private let homeService: HomeServiceProtocol
+    private let routineUseCase: RoutineUseCaseProtocol
+    private let routineRepository: RoutineRepositoryProtocol
+    private let routineService: RoutineServiceProtocol
     
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
         self.homeService = HomeService()
         self.homeRepository = HomeRepository(homeService: homeService)
         self.homeUseCase = HomeUseCase(homeRepository: homeRepository)
+        self.routineService = RoutineService()
+        self.routineRepository = RoutineRepository(routineService: routineService)
+        self.routineUseCase = RoutineUseCase(routineRepository: routineRepository)
     }
     
     func start() {
@@ -44,24 +50,24 @@ final class HomeCoordinator: Coordinator {
     }
     
     func moveToAllRoutine() {
-        let viewModel = AllRoutineViewModel()
+        let viewModel = AllRoutineViewModel(routineUseCase: routineUseCase)
         let vc = AllRoutineViewController(viewModel: viewModel)
         navigationController.pushViewController(vc, animated: true)
     }
     
     func moveToTodayRoutine() {
-        let viewModel = TodayRoutineViewModel()
+        let viewModel = TodayRoutineViewModel(routineUseCase: routineUseCase)
         let vc = TodayRoutineViewController(viewModel: viewModel)
         vc.coordinator = self
         navigationController.pushViewController(vc, animated: true)
     }
     
     func moveToWorkplaceRoutineList(with todayRoutine: TodayRoutine) {
-        let viewModel = WorkplaceRoutineListViewModel()
+        let viewModel = WorkplaceRoutineListViewModel(routineUseCase: routineUseCase)
         let vc = WorkplaceRoutineListViewController(
             viewModel: viewModel,
-            workplaceName: todayRoutine.workplaceName,
-            routines: todayRoutine.routines
+            workplaceName: todayRoutine.workplaceSummary.name,
+            workId: todayRoutine.workId
         )
         navigationController.pushViewController(vc, animated: true)
     }

--- a/MOUP/MOUP/Data/DTO/Response/HomeOwnerResponseDTOs.swift
+++ b/MOUP/MOUP/Data/DTO/Response/HomeOwnerResponseDTOs.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct HomeOwnerResponseDTO: Codable {
+struct HomeOwnerResponseDTO: Decodable {
     let nowMonth: Int
     let totalSalary: Int
     let prevMonthSalaryDiff: Int
@@ -15,12 +15,12 @@ struct HomeOwnerResponseDTO: Codable {
     let ownerMonthlyWorkplaceSummaryInfoList: [OwnerMonthlyWorkplaceSummaryInfoDTO]
 }
 
-struct OwnerMonthlyWorkplaceSummaryInfoDTO: Codable {
+struct OwnerMonthlyWorkplaceSummaryInfoDTO: Decodable {
     let workplaceSummaryInfo: WorkplaceSummaryInfoDTO
     let monthlyWorkerSummaryInfoList: [MonthlyWorkerSummaryInfoDTO]
 }
 
-struct MonthlyWorkerSummaryInfoDTO: Codable {
+struct MonthlyWorkerSummaryInfoDTO: Decodable {
     let nickname: String
     let totalWorkMinutes: Int
     let grossIncome: Int

--- a/MOUP/MOUP/Data/DTO/Response/HomeWorkerResponseDTOs.swift
+++ b/MOUP/MOUP/Data/DTO/Response/HomeWorkerResponseDTOs.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct HomeWorkerResponseDTO: Codable {
+struct HomeWorkerResponseDTO: Decodable {
     let nowMonth: Int
     let totalSalary: Int
     let prevMonthSalaryDiff: Int
@@ -15,7 +15,7 @@ struct HomeWorkerResponseDTO: Codable {
     let workerMonthlyWorkplaceSummaryInfoList: [WorkerMonthlyWorkplaceSummaryInfoDTO]
 }
 
-struct WorkerMonthlyWorkplaceSummaryInfoDTO: Codable {
+struct WorkerMonthlyWorkplaceSummaryInfoDTO: Decodable {
     let homeWorkplaceSummaryInfo: HomeWorkplaceSummaryInfoDTO
     let daysUntilPayday: Int?
     let totalWorkMinutes: Int
@@ -33,12 +33,12 @@ struct WorkerMonthlyWorkplaceSummaryInfoDTO: Codable {
     let netIncome: Int
 }
 
-struct HomeWorkplaceSummaryInfoDTO: Codable {
+struct HomeWorkplaceSummaryInfoDTO: Decodable {
     let workplaceSummaryInfo: WorkplaceSummaryInfoDTO
     let isNowWorking: Bool?
 }
 
-struct WorkplaceSummaryInfoDTO: Codable {
+struct WorkplaceSummaryInfoDTO: Decodable {
     let workplaceId: Int
     let workplaceName: String
     let isShared: Bool

--- a/MOUP/MOUP/Data/DTO/Response/RoutineResponseDTOs.swift
+++ b/MOUP/MOUP/Data/DTO/Response/RoutineResponseDTOs.swift
@@ -29,8 +29,15 @@ struct AllRoutineResponseDTO: Decodable {
     let routineSummaryInfoList: [RoutineSummaryDTO]
 }
 
+/// 루틴 요약 정보 리스트 응답 DTO
+struct RoutineSummaryListResponseDTO: Decodable {
+    let routineSummaryInfoList: [RoutineSummaryDTO]
+}
+
 struct RoutineSummaryDTO: Decodable {
     let routineId: Int
     let routineName: String
     let alarmTime: String?
 }
+
+

--- a/MOUP/MOUP/Data/DTO/Response/RoutineResponseDTOs.swift
+++ b/MOUP/MOUP/Data/DTO/Response/RoutineResponseDTOs.swift
@@ -2,17 +2,35 @@
 //  RoutineResponseDTOs.swift
 //  MOUP
 //
-//  Created by 서동환 on 10/29/25.
+//  Created by 송규섭 on 10/31/25.
 //
 
-/// 루틴 요약 정보 응답 DTO
-struct RoutineSummaryResponseDTO: Decodable {
+import Foundation
+
+struct TodayRoutineResponseDTO: Decodable {
+    let todayWorkRoutineCountList: [TodayWorkRoutineCountDTO]
+}
+
+struct TodayWorkRoutineCountDTO: Decodable {
+    let workId: Int
+    let workplaceSummaryInfo: WorkplaceSummaryInfoDTO
+    let startTime: String
+    let endTime: String
+    let workMinutes: Int
+    let routineCount: Int
+}
+
+/// 근무 ID에 해당하는 루틴
+struct WorkRoutineResponseDTO: Decodable {
+    let routineSummaryInfoList: [RoutineSummaryDTO]
+}
+
+struct AllRoutineResponseDTO: Decodable {
+    let routineSummaryInfoList: [RoutineSummaryDTO]
+}
+
+struct RoutineSummaryDTO: Decodable {
     let routineId: Int
     let routineName: String
     let alarmTime: String?
-}
-
-/// 루틴 요약 정보 리스트 응답 DTO
-struct RoutineSummaryListResponseDTO: Decodable {
-    let routineSummaryInfoList: [RoutineSummaryResponseDTO]
 }

--- a/MOUP/MOUP/Data/DTO/Response/WorkResponseDTOs.swift
+++ b/MOUP/MOUP/Data/DTO/Response/WorkResponseDTOs.swift
@@ -17,7 +17,7 @@ struct WorkDetailResponseDTO: Decodable {
     let workId: Int
     let workerSummaryInfo: WorkerSummaryResponseDTO
     let workplaceSummaryInfo: WorkplaceSummaryResponseDTO
-    let routineSummaryInfoList: [RoutineSummaryResponseDTO]
+    let routineSummaryInfoList: [RoutineSummaryDTO]
     let workDate: String
     let startTime: Date
     let actualStartTime: Date?

--- a/MOUP/MOUP/Data/Repositories/RoutineRepository.swift
+++ b/MOUP/MOUP/Data/Repositories/RoutineRepository.swift
@@ -1,0 +1,61 @@
+//
+//  RoutineRepository.swift
+//  MOUP
+//
+//  Created by 송규섭 on 10/31/25.
+//
+
+import Foundation
+
+final class RoutineRepository: RoutineRepositoryProtocol {
+    private let routineService: RoutineServiceProtocol
+    
+    init(routineService: RoutineServiceProtocol) {
+        self.routineService = routineService
+    }
+    
+    func fetchTodayRoutines() async throws -> [TodayRoutine] {
+        let response = try await routineService.fetchTodaysRoutine()
+        let todayRoutines = response.todayWorkRoutineCountList.map { dto in
+            TodayRoutine(
+                workId: dto.workId,
+                workplaceSummary: WorkplaceSummary(
+                    id: dto.workplaceSummaryInfo.workplaceId,
+                    name: dto.workplaceSummaryInfo.workplaceName,
+                    isShared: dto.workplaceSummaryInfo.isShared
+                ),
+                startTime: dto.startTime,
+                endTime: dto.endTime,
+                workMinutes: dto.workMinutes,
+                routineCount: dto.routineCount
+            )
+        }
+        return todayRoutines
+    }
+    
+    func fetchWorkRoutines(workId: Int) async throws -> [RoutineSummary] {
+        let response = try await routineService.fetchWorkRoutines(workId: workId)
+        let workRoutines = response.routineSummaryInfoList.map { dto in
+            RoutineSummary(
+                routineId: dto.routineId,
+                routineName: dto.routineName,
+                alarmTime: dto.alarmTime
+            )
+        }
+        
+        return workRoutines
+    }
+    
+    func fetchAllRoutines() async throws -> [RoutineSummary] {
+        let response = try await routineService.fetchAllRoutines()
+        let routines = response.routineSummaryInfoList.map { dto in
+            RoutineSummary(
+                routineId: dto.routineId,
+                routineName: dto.routineName,
+                alarmTime: dto.alarmTime
+            )
+        }
+        
+        return routines
+    }
+}

--- a/MOUP/MOUP/Data/Routers/RoutineRouter.swift
+++ b/MOUP/MOUP/Data/Routers/RoutineRouter.swift
@@ -1,0 +1,75 @@
+//
+//  RoutineRouter.swift
+//  MOUP
+//
+//  Created by 송규섭 on 10/30/25.
+//
+
+import Foundation
+import Alamofire
+
+enum RoutineRouter {
+    case fetchTodayRoutines
+    case fetchWorkRoutines(workId: Int)
+    case fetchAllRoutines
+}
+
+extension RoutineRouter: URLRequestConvertible {
+    var baseURL: URL {
+        guard let url = URL(string: NetworkConstants.baseURL) else {
+            fatalError("Invalid base URL")
+        }
+        return url
+    }
+
+    var path: String {
+        switch self {
+        case .fetchTodayRoutines:
+            return "/routines/today"
+        case .fetchWorkRoutines(let workId):
+            return "/routines/works/\(workId)/routines"
+        case .fetchAllRoutines:
+            return "/routines"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .fetchTodayRoutines, .fetchWorkRoutines, .fetchAllRoutines:
+            return .get
+        }
+    }
+
+    var requestBody: Encodable? {
+        switch self {
+        case .fetchTodayRoutines, .fetchWorkRoutines, .fetchAllRoutines:
+            return nil
+        }
+    }
+
+    var encoding: ParameterEncoding {
+        switch self {
+        case .fetchTodayRoutines, .fetchWorkRoutines, .fetchAllRoutines:
+            return URLEncoding.default
+        }
+    }
+
+    func asURLRequest() throws -> URLRequest {
+        let url = baseURL.appendingPathComponent(path)
+        print("최종 url: \(url)")
+        var request = try URLRequest(url: url, method: method)
+
+        if let body = requestBody {
+            let encoder = JSONEncoder()
+            request.httpBody = try encoder.encode(body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            if let httpBody = request.httpBody {
+                print("Request body: \(String(data: httpBody, encoding: .utf8) ?? "")")
+            }
+
+        }
+
+        return request
+    }
+}

--- a/MOUP/MOUP/Data/Services/RoutineService.swift
+++ b/MOUP/MOUP/Data/Services/RoutineService.swift
@@ -1,0 +1,76 @@
+//
+//  RoutineService.swift
+//  MOUP
+//
+//  Created by 송규섭 on 10/31/25.
+//
+
+import os
+import Foundation
+import Alamofire
+
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "RoutineService")
+
+protocol RoutineServiceProtocol: AnyObject {
+    func fetchTodaysRoutine() async throws -> TodayRoutineResponseDTO
+    func fetchWorkRoutines(workId: Int) async throws -> WorkRoutineResponseDTO
+    func fetchAllRoutines() async throws -> AllRoutineResponseDTO
+}
+
+final class RoutineService: RoutineServiceProtocol {
+    private let session = NetworkManager.shared.session
+    
+    func fetchTodaysRoutine() async throws -> TodayRoutineResponseDTO {
+        let request = session.request(RoutineRouter.fetchTodayRoutines)
+        let response = await request.serializingDecodable(TodayRoutineResponseDTO.self).response
+        
+        let statusCode = response.response?.statusCode
+        logger.debug("statusCode: \(statusCode ?? 0)")
+        
+        switch statusCode {
+        case 200:
+            guard let dto = response.value else {
+                throw NetworkError.noResponse
+            }
+            return dto
+        default:
+            throw NetworkError.serverError
+        }
+    }
+    
+    func fetchWorkRoutines(workId: Int) async throws -> WorkRoutineResponseDTO {
+        let request = session.request(RoutineRouter.fetchWorkRoutines(workId: workId))
+        let response = await request.serializingDecodable(WorkRoutineResponseDTO.self).response
+        
+        let statusCode = response.response?.statusCode
+        logger.debug("statusCode: \(statusCode ?? 0)")
+        
+        switch statusCode {
+        case 200:
+            guard let dto = response.value else {
+                throw NetworkError.noResponse
+            }
+            return dto
+        default:
+            throw NetworkError.serverError
+        }
+    }
+    
+    func fetchAllRoutines() async throws -> AllRoutineResponseDTO {
+        let request = session.request(RoutineRouter.fetchAllRoutines)
+        let response = await request.serializingDecodable(AllRoutineResponseDTO.self).response
+        
+        let statusCode = response.response?.statusCode
+        logger.debug("statusCode: \(statusCode ?? 0)")
+        
+        switch statusCode {
+        case 200:
+            guard let dto = response.value else {
+                throw NetworkError.noResponse
+            }
+            return dto
+        default:
+            throw NetworkError.serverError
+        }
+    }
+}

--- a/MOUP/MOUP/Domain/Entities/Routine/RoutineSummary.swift
+++ b/MOUP/MOUP/Domain/Entities/Routine/RoutineSummary.swift
@@ -10,5 +10,5 @@ import Foundation
 struct RoutineSummary {
     let routineId: Int
     let routineName: String
-    let alarmTime: String
+    let alarmTime: String?
 }

--- a/MOUP/MOUP/Domain/Entities/Routine/RoutineSummary.swift
+++ b/MOUP/MOUP/Domain/Entities/Routine/RoutineSummary.swift
@@ -1,0 +1,14 @@
+//
+//  RoutineSummary.swift
+//  MOUP
+//
+//  Created by 송규섭 on 10/31/25.
+//
+
+import Foundation
+
+struct RoutineSummary {
+    let routineId: Int
+    let routineName: String
+    let alarmTime: String
+}

--- a/MOUP/MOUP/Domain/Entities/Routine/TodayRoutine.swift
+++ b/MOUP/MOUP/Domain/Entities/Routine/TodayRoutine.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 struct TodayRoutine {
-    let workplaceName: String
-    let routines: [Routine]
+    let workId: Int
+    let workplaceSummary: WorkplaceSummary
+    let startTime: String
+    let endTime: String
+    let workMinutes: Int
+    let routineCount: Int
 }

--- a/MOUP/MOUP/Domain/Interfaces/Repositories/RoutineRepositoryProtocol.swift
+++ b/MOUP/MOUP/Domain/Interfaces/Repositories/RoutineRepositoryProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  RoutineRepositoryProtocol.swift
+//  MOUP
+//
+//  Created by 송규섭 on 10/31/25.
+//
+
+import Foundation
+
+protocol RoutineRepositoryProtocol: AnyObject {
+    func fetchTodayRoutines() async throws -> [TodayRoutine]
+    func fetchWorkRoutines(workId: Int) async throws -> [RoutineSummary]
+    func fetchAllRoutines() async throws -> [RoutineSummary]
+}

--- a/MOUP/MOUP/Domain/Interfaces/UseCases/RoutineUseCaseProtocol.swift
+++ b/MOUP/MOUP/Domain/Interfaces/UseCases/RoutineUseCaseProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  RoutineUseCaseProtocol.swift
+//  MOUP
+//
+//  Created by 송규섭 on 10/31/25.
+//
+
+import Foundation
+
+protocol RoutineUseCaseProtocol: AnyObject {
+    func fetchTodayRoutines() async throws -> [TodayRoutine]
+    func fetchWorkRoutines(workId: Int) async throws -> [RoutineSummary]
+    func fetchAllRoutines() async throws -> [RoutineSummary]
+}

--- a/MOUP/MOUP/Domain/UseCases/RoutineUseCase.swift
+++ b/MOUP/MOUP/Domain/UseCases/RoutineUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  RoutineUseCase.swift
+//  MOUP
+//
+//  Created by 송규섭 on 10/31/25.
+//
+
+import Foundation
+
+final class RoutineUseCase: RoutineUseCaseProtocol {
+    private let routineRepository: RoutineRepositoryProtocol
+    
+    init(routineRepository: RoutineRepositoryProtocol) {
+        self.routineRepository = routineRepository
+    }
+    
+    func fetchTodayRoutines() async throws -> [TodayRoutine] {
+        try await routineRepository.fetchTodayRoutines()
+    }
+    
+    func fetchWorkRoutines(workId: Int) async throws -> [RoutineSummary] {
+        try await routineRepository.fetchWorkRoutines(workId: workId)
+    }
+    
+    func fetchAllRoutines() async throws -> [RoutineSummary] {
+        try await routineRepository.fetchAllRoutines()
+    }
+}

--- a/MOUP/MOUP/Presentation/Components/NoticeModalViewController.swift
+++ b/MOUP/MOUP/Presentation/Components/NoticeModalViewController.swift
@@ -16,6 +16,7 @@ class NoticeModalViewController: UIViewController {
     private let disposeBag = DisposeBag()
     private let noticeTitle: String
     private let comment: String
+    var onConfirm: (() -> Void)?
     
     // MARK: - UI Components
     private let dimmedView = UIView().then {
@@ -46,9 +47,10 @@ class NoticeModalViewController: UIViewController {
     private let confirmButton = BaseButton(title: "확인", isSecondary: false)
     
     // MARK: - Initializer
-    init(title: String, comment: String) {
+    init(title: String, comment: String, onConfirm: (() -> Void)? = nil) {
         self.noticeTitle = title
         self.comment = comment
+        self.onConfirm = onConfirm
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -123,7 +125,9 @@ private extension NoticeModalViewController {
         confirmButton.rx.tap
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
-                self.dismiss(animated: true)
+                owner.dismiss(animated: true) {
+                    owner.onConfirm?()
+                }
             })
             .disposed(by: disposeBag)
     }

--- a/MOUP/MOUP/Presentation/Home/View/HomeView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/HomeView.swift
@@ -15,6 +15,7 @@ import Then
 final class HomeView: UIView {
     // MARK: - Properties
     private let userRole: UserRole
+    private var isTableHeaderViewConfigured = false
     
     // MARK: - UI Components
     private let topBar = UIView()
@@ -60,7 +61,11 @@ final class HomeView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        
+        // viewDidLoad, init에서 호출 시 제약조건 충돌 발생으로 인해 플래그 사용
+        if !isTableHeaderViewConfigured && bounds.width > 0 {
+            setTableHeaderView()
+            isTableHeaderViewConfigured = true
+        }
     }
     
     // MARK: - Public Methods
@@ -82,7 +87,6 @@ private extension HomeView {
         setHierarchy()
         setStyles()
         setConstraints()
-        setTableHeaderView()
     }
     
     // MARK: - setHierarchy

--- a/MOUP/MOUP/Presentation/Home/View/HomeView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/HomeView.swift
@@ -132,7 +132,6 @@ private extension HomeView {
         // TODO: - 테이블뷰 셀 상단 영역 8을 그림자를 위해 남겨놨으니 설정 필요
         guard let rawValue = UserDefaultsManager.shared.userRole,
         let role = UserRole(rawValue: rawValue) else { return }
-        self.tableHeaderView = HomeHeaderContainerView(userRole: role)
         tableHeaderView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 332)
         tableView.tableHeaderView = tableHeaderView
     }

--- a/MOUP/MOUP/Presentation/Home/View/HomeView.swift
+++ b/MOUP/MOUP/Presentation/Home/View/HomeView.swift
@@ -15,7 +15,7 @@ import Then
 final class HomeView: UIView {
     // MARK: - Properties
     private let userRole: UserRole
-    private var isTableHeaderViewConfigured = false
+    private var didConfigureTableHeaderView = false
     
     // MARK: - UI Components
     private let topBar = UIView()
@@ -62,9 +62,9 @@ final class HomeView: UIView {
         super.layoutSubviews()
         
         // viewDidLoad, init에서 호출 시 제약조건 충돌 발생으로 인해 플래그 사용
-        if !isTableHeaderViewConfigured && bounds.width > 0 {
+        if !didConfigureTableHeaderView && bounds.width > 0 {
             setTableHeaderView()
-            isTableHeaderViewConfigured = true
+            didConfigureTableHeaderView = true
         }
     }
     

--- a/MOUP/MOUP/Presentation/Routine/View/Cell/RoutineListCell.swift
+++ b/MOUP/MOUP/Presentation/Routine/View/Cell/RoutineListCell.swift
@@ -50,7 +50,7 @@ class RoutineListCell: UITableViewCell {
     // MARK: - Public Methods
     func update(with routine: RoutineSummary) {
         titleLabel.text = routine.routineName
-        alarmTimeLabel.text = routine.alarmTime
+        alarmTimeLabel.text = routine.alarmTime ?? ""
     }
     
 }

--- a/MOUP/MOUP/Presentation/Routine/View/Cell/RoutineListCell.swift
+++ b/MOUP/MOUP/Presentation/Routine/View/Cell/RoutineListCell.swift
@@ -48,9 +48,9 @@ class RoutineListCell: UITableViewCell {
     }
     
     // MARK: - Public Methods
-    func update(with routine: Routine) {
-        titleLabel.text = routine.title
-        alarmTimeLabel.text = String(format: "%02d : %02d", routine.alarmTime?.hour ?? 0, routine.alarmTime?.minute ?? 0)
+    func update(with routine: RoutineSummary) {
+        titleLabel.text = routine.routineName
+        alarmTimeLabel.text = routine.alarmTime
     }
     
 }

--- a/MOUP/MOUP/Presentation/Routine/View/Cell/TodayRoutineCell.swift
+++ b/MOUP/MOUP/Presentation/Routine/View/Cell/TodayRoutineCell.swift
@@ -48,9 +48,9 @@ class TodayRoutineCell: UITableViewCell {
     }
     
     // MARK: - Public Methods
-    func update(with routines: TodayRoutine) {
-        workplaceNameLabel.text = routines.workplaceName
-        routineCountLabel.text = "+ \(routines.routines.count)"
+    func update(with routine: TodayRoutine) {
+        workplaceNameLabel.text = routine.workplaceSummary.name
+        routineCountLabel.text = "+ \(routine.routineCount)"
     }
 }
 

--- a/MOUP/MOUP/Presentation/Routine/ViewController/AllRoutineViewController.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewController/AllRoutineViewController.swift
@@ -64,6 +64,15 @@ private extension AllRoutineViewController {
         allRoutineView.setupTableView(section: output.allRoutines, dataSource: dataSources)
             .disposed(by: disposeBag)
         
+        output.errorMessage
+            .withUnretained(self)
+            .subscribe(onNext: { owner, error in
+                owner.presentNoticeModal(title: error.title, comment: error.message) {
+                    owner.navigationController?.popViewController(animated: true)
+                }
+            })
+            .disposed(by: disposeBag)
+        
         Observable.zip(
             allRoutineView.rx.itemSelected,
             allRoutineView.rx.modelSeleted

--- a/MOUP/MOUP/Presentation/Routine/ViewController/TodayRoutineViewController.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewController/TodayRoutineViewController.swift
@@ -75,7 +75,7 @@ private extension TodayRoutineViewController {
                     owner.presentNoticeModal(
                         title: error.title,
                         comment: error.message) {
-                            owner.dismiss(animated: true)
+                            owner.navigationController?.popViewController(animated: true)
                         }
             })
             .disposed(by: disposeBag)

--- a/MOUP/MOUP/Presentation/Routine/ViewController/TodayRoutineViewController.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewController/TodayRoutineViewController.swift
@@ -66,6 +66,20 @@ private extension TodayRoutineViewController {
         )
         .disposed(by: disposeBag)
         
+        output.errorMessage
+            .withUnretained(self)
+            .subscribe(
+                onNext: {
+                    owner,
+                    error in
+                    owner.presentNoticeModal(
+                        title: error.title,
+                        comment: error.message) {
+                            owner.dismiss(animated: true)
+                        }
+            })
+            .disposed(by: disposeBag)
+        
         Observable.zip(
             todayRoutineView.rx.itemSelected,
             todayRoutineView.rx.modelSelected

--- a/MOUP/MOUP/Presentation/Routine/ViewController/WorkplaceRoutineListViewController.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewController/WorkplaceRoutineListViewController.swift
@@ -14,7 +14,7 @@ class WorkplaceRoutineListViewController: UIViewController {
     private let disposeBag = DisposeBag()
     private let viewModel: WorkplaceRoutineListViewModel
     private let workplaceRoutineListView: WorkplaceRoutineListView
-    private let routines: [Routine]
+    private let workId: Int
     private let dataSource = RxTableViewSectionedReloadDataSource<RoutineItem>(
         configureCell: { dataSource, tableView, indexPath, item in
             guard let cell = tableView.dequeueReusableCell(withIdentifier: RoutineListCell.identifier, for: indexPath) as? RoutineListCell else {
@@ -31,10 +31,10 @@ class WorkplaceRoutineListViewController: UIViewController {
     }
     
     // MARK: - Initializer
-    init(viewModel: WorkplaceRoutineListViewModel, workplaceName: String, routines: [Routine]) {
+    init(viewModel: WorkplaceRoutineListViewModel, workplaceName: String, workId: Int) {
         self.viewModel = viewModel
         self.workplaceRoutineListView = WorkplaceRoutineListView(workplaceName: workplaceName)
-        self.routines = routines
+        self.workId = workId
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -58,13 +58,20 @@ private extension WorkplaceRoutineListViewController {
     }
     
     func setBindings() {
-        let input = WorkplaceRoutineListViewModel.Input(routines: Observable.just(routines))
+        let input = WorkplaceRoutineListViewModel.Input(workId: Observable.just(workId))
         let output = viewModel.transform(input: input)
         
         workplaceRoutineListView.setupTableView(
             section: output.routineItem,
             dataSource: dataSource
         )
+            .disposed(by: disposeBag)
+        
+        output.errorMessage
+            .withUnretained(self)
+            .subscribe(onNext: { owner, error in
+                owner.presentNoticeModal(title: error.title, comment: error.message)
+            })
             .disposed(by: disposeBag)
         
         workplaceRoutineListView.rx.navBackBtnTapped

--- a/MOUP/MOUP/Presentation/Routine/ViewController/WorkplaceRoutineListViewController.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewController/WorkplaceRoutineListViewController.swift
@@ -70,7 +70,9 @@ private extension WorkplaceRoutineListViewController {
         output.errorMessage
             .withUnretained(self)
             .subscribe(onNext: { owner, error in
-                owner.presentNoticeModal(title: error.title, comment: error.message)
+                owner.presentNoticeModal(title: error.title, comment: error.message) {
+                    owner.navigationController?.popViewController(animated: true)
+                }
             })
             .disposed(by: disposeBag)
         

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/AllRoutineViewModel.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/AllRoutineViewModel.swift
@@ -55,7 +55,7 @@ private extension AllRoutineViewModel {
                 let routines = try await routineUseCase.fetchAllRoutines()
                 allRoutinesRelay.accept([RoutineItem(items: routines)])
             } catch {
-                errorMessageRelay.accept(("루틴 불러오기 실패", "오늘의 루틴을 불러오지 못했습니다.\n잠시 후 다시 시도해주세요."))
+                errorMessageRelay.accept(("루틴 불러오기 실패", "전체 루틴을 불러오지 못했습니다.\n잠시 후 다시 시도해주세요."))
             }
         }
     }

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/AllRoutineViewModel.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/AllRoutineViewModel.swift
@@ -12,18 +12,14 @@ import RxRelay
 final class AllRoutineViewModel {
     // MARK: - Properties
     private let disposeBag = DisposeBag()
-    private let mockAllRoutines = [RoutineItem(items: [
-        Routine(id: UUID(), title: "폐기", alarmTime: DateComponents(hour: 13, minute: 30), items: [
-            TodoItem(text: "pp 매대 유통기한 검수"),
-            TodoItem(text: "빵 라인 유통기한 검수")
-        ]),
-        Routine(id: UUID(), title: "치킨", alarmTime: DateComponents(hour: 10, minute: 0), items: [
-            TodoItem(text: "바삭통다리 2개"),
-            TodoItem(text: "더큰지파이 2개"),
-            TodoItem(text: "치즈볼 3개")
-        ])
-    ])]
+    private let routineUseCase: RoutineUseCaseProtocol
     private let allRoutinesRelay = BehaviorRelay<[RoutineItem]>(value: [])
+    private let errorMessageRelay = PublishRelay<(title: String, message: String)>()
+    
+    // MARK: - Initializer
+    init(routineUseCase: RoutineUseCaseProtocol) {
+        self.routineUseCase = routineUseCase
+    }
     
     // MARK: - Input, Output
     struct Input {
@@ -32,6 +28,7 @@ final class AllRoutineViewModel {
     
     struct Output {
         let allRoutines: Observable<[RoutineItem]>
+        let errorMessage: Observable<(title: String, message: String)>
     }
     
     // MARK: - transform
@@ -39,13 +36,27 @@ final class AllRoutineViewModel {
         input.viewDidLoad
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
-                owner.allRoutinesRelay.accept(owner.mockAllRoutines)
+                owner.fetchAllRoutines()
             })
             .disposed(by: disposeBag)
         
         return Output(
-            allRoutines: allRoutinesRelay.asObservable()
+            allRoutines: allRoutinesRelay.asObservable(),
+            errorMessage: errorMessageRelay.asObservable()
         )
     }
     
+}
+
+private extension AllRoutineViewModel {
+    func fetchAllRoutines() {
+        Task {
+            do {
+                let routines = try await routineUseCase.fetchAllRoutines()
+                allRoutinesRelay.accept([RoutineItem(items: routines)])
+            } catch {
+                errorMessageRelay.accept(("루틴 불러오기 실패", "오늘의 루틴을 불러오지 못했습니다.\n잠시 후 다시 시도해주세요."))
+            }
+        }
+    }
 }

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/Items/RoutineItem.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/Items/RoutineItem.swift
@@ -13,9 +13,9 @@ struct RoutineItem {
 }
 
 extension RoutineItem: SectionModelType {
-    typealias Item = Routine
+    typealias Item = RoutineSummary
     
-    init(original: RoutineItem, items: [Routine]) {
+    init(original: RoutineItem, items: [RoutineSummary]) {
         self = original
         self.items = items
     }

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/TodayRoutineViewModel.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/TodayRoutineViewModel.swift
@@ -12,35 +12,13 @@ import RxRelay
 final class TodayRoutineViewModel {
     // MARK: - Properties
     private let disposeBag = DisposeBag()
+    private let routineUseCase: RoutineUseCaseProtocol
     private let todayRoutineRelay = BehaviorRelay<[TodayRoutineItem]>(value: [])
-    private let mockTodayRoutines = [
-        TodayRoutineItem(
-            items: [
-                TodayRoutine(
-                    workplaceName: "GS25 한신점",
-                    routines: [Routine(
-                        id: UUID(),
-                        title: "치킨",
-                        alarmTime: DateComponents(hour: 10, minute: 0),
-                        items: [
-                            TodoItem(text: "바삭통다리 2개"),
-                            TodoItem(text: "매운바삭치킨 2개")
-                        ]
-                    ),
-                               Routine(
-                                id: UUID(),
-                                title: "청소",
-                                alarmTime: DateComponents(hour: 14, minute: 30),
-                                items: [
-                                    TodoItem(text: "내부 테이블 정리"),
-                                    TodoItem(text: "외부 테라스 분리수거")
-                                ]
-                               )
-                    ]
-                )
-            ]
-        )
-    ]
+    private let errorMessageRelay = PublishRelay<(title: String, message: String)>()
+    
+    init(routineUseCase: RoutineUseCaseProtocol) {
+        self.routineUseCase = routineUseCase
+    }
     
     // MARK: - Input, Output
     struct Input {
@@ -49,6 +27,7 @@ final class TodayRoutineViewModel {
     
     struct Output {
         let todayRoutine: Observable<[TodayRoutineItem]>
+        let errorMessage: Observable<(title: String, message: String)>
     }
     
     // MARK: - transform
@@ -56,13 +35,28 @@ final class TodayRoutineViewModel {
         input.viewDidLoad
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
-                owner.todayRoutineRelay.accept(owner.mockTodayRoutines)
+                owner.fetchTodayRoutines()
             })
             .disposed(by: disposeBag)
         
         return Output(
-            todayRoutine: todayRoutineRelay.asObservable()
+            todayRoutine: todayRoutineRelay.asObservable(),
+            errorMessage: errorMessageRelay.asObservable()
         )
     }
     
+}
+
+private extension TodayRoutineViewModel {
+    func fetchTodayRoutines() {
+        Task {
+            do {
+                let todayRoutines = try await routineUseCase.fetchTodayRoutines()
+                let todayRoutineItem = TodayRoutineItem(items: todayRoutines)
+                todayRoutineRelay.accept([todayRoutineItem])
+            } catch {
+                errorMessageRelay.accept(("루틴 불러오기 실패", "오늘의 루틴을 불러오지 못했습니다.\n잠시 후 다시 시도해주세요."))
+            }
+        }
+    }
 }

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/WorkplaceRoutineListViewModel.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/WorkplaceRoutineListViewModel.swift
@@ -12,34 +12,52 @@ import RxRelay
 final class WorkplaceRoutineListViewModel {
     // MARK: - Properties
     private let disposeBag = DisposeBag()
+    private let routineUseCase: RoutineUseCaseProtocol
     private let routinesRelay = BehaviorRelay<[RoutineItem]>(value: [])
+    private let errorMessageRelay = PublishRelay<(title: String, message: String)>()
     
     // MARK: - Initializer
+    init(routineUseCase: RoutineUseCaseProtocol) {
+        self.routineUseCase = routineUseCase
+    }
     
     // MARK: - Input, Output
     struct Input {
-        let routines: Observable<[Routine]>
+        let workId: Observable<Int>
     }
     
     struct Output {
         let routineItem: Observable<[RoutineItem]>
+        let errorMessage: Observable<(title: String, message: String)>
     }
     
     // MARK: - transform
     func transform(input: Input) -> Output {
-        input.routines
+        input.workId
             .withUnretained(self)
-            .subscribe(onNext: { owner, routines in
-                let routineItem = [
-                    RoutineItem(items: routines)
-                ]
-                owner.routinesRelay.accept(routineItem)
+            .subscribe(onNext: { owner, id in
+                owner.fetchWorkRoutines(workId: id)
             })
             .disposed(by: disposeBag)
         
         return Output(
-            routineItem: routinesRelay.asObservable()
+            routineItem: routinesRelay.asObservable(),
+            errorMessage: errorMessageRelay.asObservable()
         )
     }
-    
+}
+
+private extension WorkplaceRoutineListViewModel {
+    func fetchWorkRoutines(workId: Int) {
+        Task {
+            do {
+                let routines = try await routineUseCase.fetchWorkRoutines(workId: workId)
+                routinesRelay.accept([
+                    RoutineItem(items: routines)
+                ])
+            } catch {
+                errorMessageRelay.accept(("루틴 불러오기 실패", "오늘의 루틴을 불러오지 못했습니다.\n잠시 후 다시 시도해주세요."))
+            }
+        }
+    }
 }

--- a/MOUP/MOUP/Presentation/Routine/ViewModel/WorkplaceRoutineListViewModel.swift
+++ b/MOUP/MOUP/Presentation/Routine/ViewModel/WorkplaceRoutineListViewModel.swift
@@ -56,7 +56,7 @@ private extension WorkplaceRoutineListViewModel {
                     RoutineItem(items: routines)
                 ])
             } catch {
-                errorMessageRelay.accept(("루틴 불러오기 실패", "오늘의 루틴을 불러오지 못했습니다.\n잠시 후 다시 시도해주세요."))
+                errorMessageRelay.accept(("루틴 불러오기 실패", "루틴을 불러오지 못했습니다.\n잠시 후 다시 시도해주세요."))
             }
         }
     }

--- a/MOUP/MOUP/Resources/Info.plist
+++ b/MOUP/MOUP/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>User Interface Style</key>
+	<string>Light</string>
 	<key>BaseURL</key>
 	<string>$(BASE_URL)</string>
 	<key>CFBundleIconName</key>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #55 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 오늘의 루틴을 불러오고 내부 셀을 눌렀을 때 해당 근무지에 연관된 루틴을 불러오도록 구현했습니다.
- 전체 루틴을 불러오도록 구현했습니다.
- 루틴을 불러오지 못했을 예외 상황에서 기존 confirmModal을 띄워 뒤로가도록 구현했습니다.
- 위와 같이 뒤로가도록 유도할 수 있게 confirmModal 내 확인 버튼을 누를 시 클로저를 주입받아 completion에 추가했습니다.
- 참고 사항으로, Routine 관련 DTO에서 같은 프로퍼티를 담고 있는 경우가 있는데 목적이 다름을 명확히 하기 위해 분리해두었습니다.

<br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/a463d58f-209c-4218-bbd4-53d30fc6887a" width ="250"> |

<br>
