### PR TITLE
fix: 캘린더에서 간헐적으로 토요일 열이 사라지는 현상 수정

### DIFF
--- a/MOUP/MOUP/Presentation/Calendar/View/CalendarView.swift
+++ b/MOUP/MOUP/Presentation/Calendar/View/CalendarView.swift
@@ -56,8 +56,10 @@ final class CalendarView: UIView {
         if availableLayoutWidth <= 0 { return }
         let availableDayCellWidth = floor(availableLayoutWidth / 7.0)
         let availableCalendarWidth = availableDayCellWidth * 7
-        if calendarWidthConstraint?.layoutConstraints.first?.constant == availableCalendarWidth { return }
-        calendarWidthConstraint?.update(offset: availableCalendarWidth)
+        guard let calendarWidthConstraintConstant = calendarWidthConstraint?.layoutConstraints.first?.constant else { return }
+        if !calendarWidthConstraintConstant.isEqual(to: availableCalendarWidth) {
+            calendarWidthConstraint?.update(offset: availableCalendarWidth)
+        }
     }
 }
 

--- a/MOUP/MOUP/Presentation/Calendar/View/CalendarView.swift
+++ b/MOUP/MOUP/Presentation/Calendar/View/CalendarView.swift
@@ -16,6 +16,9 @@ import Then
 /// 캘린더 UI
 final class CalendarView: UIView {
     
+    // MARK: - Properties
+    private var calendarWidthConstraint: Constraint?
+    
     // MARK: - UI Components
     /// 캘린더 상단 헤더
     private let calendarHeaderView = CalendarHeaderView()
@@ -43,6 +46,18 @@ final class CalendarView: UIView {
     @available(*, unavailable, message: "storyboard is not supported.")
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented.")
+    }
+    
+    // MARK: - Lifecycle
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        let availableLayoutWidth = self.safeAreaLayoutGuide.layoutFrame.width
+        if availableLayoutWidth <= 0 { return }
+        let availableDayCellWidth = floor(availableLayoutWidth / 7.0)
+        let availableCalendarWidth = availableDayCellWidth * 7
+        if calendarWidthConstraint?.layoutConstraints.first?.constant == availableCalendarWidth { return }
+        calendarWidthConstraint?.update(offset: availableCalendarWidth)
     }
 }
 
@@ -76,14 +91,16 @@ private extension CalendarView {
         
         dayOfTheWeekHStackView.snp.makeConstraints {
             $0.top.equalTo(calendarHeaderView.snp.bottom)
-            $0.leading.trailing.equalTo(self.safeAreaLayoutGuide)
+            $0.centerX.equalTo(self.safeAreaLayoutGuide)
+            $0.width.equalTo(monthCalendarView)
             $0.height.equalTo(20)
         }
         
         monthCalendarView.snp.makeConstraints {
             $0.top.equalTo(dayOfTheWeekHStackView.snp.bottom)
-            $0.leading.trailing.equalTo(self.safeAreaLayoutGuide)
+            $0.centerX.equalTo(self.safeAreaLayoutGuide)
             $0.bottom.equalTo(self.safeAreaLayoutGuide)
+            self.calendarWidthConstraint = $0.width.equalTo(self.safeAreaLayoutGuide.layoutFrame.width).constraint
         }
     }
 }

--- a/MOUP/MOUP/Presentation/Calendar/ViewModel/CalendarViewModel.swift
+++ b/MOUP/MOUP/Presentation/Calendar/ViewModel/CalendarViewModel.swift
@@ -100,14 +100,14 @@ final class CalendarViewModel {
                             return startOfMonth...endOfMonth
                         }()
                         
-                        await MainActor.run {
-                            var currentDict = owner.calendarWorkDictRelay.value
-                            if let dateRange {
-                                let datesToRemove = currentDict.keys.filter { dateRange.contains($0) }
-                                datesToRemove.forEach { currentDict[$0] = nil }
-                            }
-                            
-                            currentDict.merge(newChunkDict) { _, newSet in newSet }
+                        var currentDict = owner.calendarWorkDictRelay.value
+                        if let dateRange {
+                            let datesToRemove = currentDict.keys.filter { dateRange.contains($0) }
+                            datesToRemove.forEach { currentDict[$0] = nil }
+                        }
+                        currentDict.merge(newChunkDict) { _, newSet in newSet }
+                        
+                        await MainActor.run { [currentDict] in
                             owner.calendarWorkDictRelay.accept(currentDict)
                         }
                         


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #89 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 캘린더에서 간헐적으로 토요일 열이 사라지는 현상 수정
- 캘린더 근무 데이터 가공을 메인 스레드에 강제하지 않도록 수정

캘린더 라이브러리에서 너비를 7로 나눠서 셀을 각 열에 표시하는 과정에서 부동 소수점 오차로 인해 셀이 화면에서 안보이게되는 버그가 발생했던 것 같습니다.
iOS 26 미만 버전에서는 발견되지 않는 것으로 보아, 26 버전부터 `didEndDisplaying` 되는 셀을 더 타이트하게 잡거나, iOS 자체의 버그일 수도 있어보입니다.
캘린더 너비를 7로 나누어떨어지도록 수정하다보니 캘린더 양쪽으로 빈 공간이 살짝 생겼습니다.(iPhone 17 Pro Max 기준 양쪽 3픽셀씩)

<br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 캘린더 스크롤 | <img src = "https://github.com/user-attachments/assets/8f11992b-e3d3-4b70-ab80-b08971c6fb50" width ="250"> |
| 캘린더 스크린샷 | <img src = "https://github.com/user-attachments/assets/d6116a24-6103-4c48-b997-fd20c42cdacd" width ="250"> |


<br>
