### PR TITLE
task: 캘린더 근무 UI 크기 조절 로직 변경

### DIFF
--- a/MOUP/MOUP/Presentation/Calendar/View/Cell/CalendarDayCell.swift
+++ b/MOUP/MOUP/Presentation/Calendar/View/Cell/CalendarDayCell.swift
@@ -54,29 +54,21 @@ final class CalendarDayCell: JTACDayCell {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        // workContainerVStackView의 minY 계산
-        let workContainerMinY = dayLabel.frame.maxY + 4
-        
-        // workContainerVStackView의 너비 계산
-        let targetWidth = self.contentView.bounds.width - 4
-        // systemLayoutSizeFitting에 전달할 목표 크기 계산 - 너비는 targetWidth, 높이는 시스템이 계산
-        let targetSize = CGSize(width: targetWidth, height: UIView.layoutFittingCompressedSize.height)
-        // targetSize를 이용하여 workContainerVStackView의 잠재적인 최대 높이 계산
-        let requiredHeight = workContainerVStackView.systemLayoutSizeFitting(targetSize,
-                                                                             withHorizontalFittingPriority: .required,
-                                                                             verticalFittingPriority: .fittingSizeLevel).height
-        // workContainerVStackView의 잠재적인 maxY 계산
-        let potentialMaxY = workContainerMinY + requiredHeight
-        
-        // workContainerVStackView의 최대 maxY 계산(여백 4 포함)
-        let possibleMaxY = self.contentView.bounds.height - 4
-        
-        // 근무 컨테이너 UI가 캘린더 셀을 벗어나거나 여백이 4 미만일 때
-        if potentialMaxY >= possibleMaxY {
-            let possibleMaxHeight = possibleMaxY - workContainerMinY
-            let reducedCount = Int(possibleMaxHeight / (WorkRowSize.baseComponentHeight + workContainerVStackView.spacing))
-            // 근무 UI 크기 줄임
-            workContainerVStackView.reduceHeight(displayCount: reducedCount)
+        DispatchQueue.main.async {
+            let workContainerMaxY = self.workContainerVStackView.frame.maxY
+            
+            // 근무 컨테이너 UI의 maxY가 가능한 최댓값
+            let possibleMaxY = self.contentView.bounds.height - 4  // 하단 여백 4 포함
+            
+            // 근무 컨테이너 UI와 캘린더 셀 사이 여백이 4 미만일 때
+            if workContainerMaxY >= possibleMaxY {
+                let workContainerMinY = self.workContainerVStackView.frame.minY
+                let possibleMaxHeight = possibleMaxY - workContainerMinY
+                
+                let reducedCount = Int(possibleMaxHeight / (WorkRowSize.baseComponentHeight + self.workContainerVStackView.spacing))
+                
+                self.workContainerVStackView.reduceHeight(displayCount: reducedCount)
+            }
         }
     }
     
@@ -111,6 +103,8 @@ final class CalendarDayCell: JTACDayCell {
         case .shared:
             workContainerVStackView.updateSharedModeWorkRows(workList: workList, displayCount: displayCount)
         }
+        
+        setNeedsLayout()
     }
 }
 

--- a/MOUP/MOUP/Presentation/Calendar/View/Cell/CalendarDayCell.swift
+++ b/MOUP/MOUP/Presentation/Calendar/View/Cell/CalendarDayCell.swift
@@ -17,6 +17,12 @@ final class CalendarDayCell: JTACDayCell {
     // MARK: - Properties
     static let identifier = String(describing: CalendarDayCell.self)
     
+    override var isSelected: Bool {
+        didSet {
+            selectedView.isHidden = !isSelected
+        }
+    }
+    
     // MARK: - UI Components
     /// 구분선
     private let seperatorView = UIView().then {
@@ -73,7 +79,7 @@ final class CalendarDayCell: JTACDayCell {
     }
     
     // MARK: - Internal Methods
-    func update(dateStr: String, isToday: Bool, daysOfWeek: DaysOfWeek, dateBelongsToThisMonth: Bool, isSelected: Bool, calendarMode: CalendarMode, workList: [WorkSummary]) {
+    func update(dateStr: String, isToday: Bool, daysOfWeek: DaysOfWeek, dateBelongsToThisMonth: Bool, calendarMode: CalendarMode, workList: [WorkSummary]) {
         dayLabel.text = dateStr
         
         if isToday {
@@ -93,7 +99,6 @@ final class CalendarDayCell: JTACDayCell {
         
         self.isUserInteractionEnabled = dateBelongsToThisMonth
         dayLabel.isHidden = !dateBelongsToThisMonth
-        selectedView.isHidden = !isSelected
         workContainerVStackView.isHidden = !dateBelongsToThisMonth
         
         let displayCount = 4

--- a/MOUP/MOUP/Presentation/Calendar/View/Cell/CalendarDayCell.swift
+++ b/MOUP/MOUP/Presentation/Calendar/View/Cell/CalendarDayCell.swift
@@ -60,13 +60,15 @@ final class CalendarDayCell: JTACDayCell {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            
             let workContainerMaxY = self.workContainerVStackView.frame.maxY
             
             // 근무 컨테이너 UI의 maxY가 가능한 최댓값
             let possibleMaxY = self.contentView.bounds.height - 4  // 하단 여백 4 포함
             
-            // 근무 컨테이너 UI와 캘린더 셀 사이 여백이 4 미만일 때
+            // 근무 컨테이너 UI와 캘린더 셀 하단 사이 여백이 4 미만일 때
             if workContainerMaxY >= possibleMaxY {
                 let workContainerMinY = self.workContainerVStackView.frame.minY
                 let possibleMaxHeight = possibleMaxY - workContainerMinY

--- a/MOUP/MOUP/Presentation/Calendar/View/Cell/CalendarDayCell.swift
+++ b/MOUP/MOUP/Presentation/Calendar/View/Cell/CalendarDayCell.swift
@@ -76,6 +76,14 @@ final class CalendarDayCell: JTACDayCell {
                 let reducedCount = Int(possibleMaxHeight / (WorkRowSize.baseComponentHeight + self.workContainerVStackView.spacing))
                 
                 self.workContainerVStackView.reduceHeight(displayCount: reducedCount)
+                
+                if self.workContainerVStackView.alpha.isEqual(to: 0.0) {
+                    UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 0.1, delay: 0) {
+                        self.workContainerVStackView.alpha = 1.0
+                    }
+                }
+            } else {
+                self.workContainerVStackView.alpha = 1.0
             }
         }
     }
@@ -103,12 +111,13 @@ final class CalendarDayCell: JTACDayCell {
         dayLabel.isHidden = !dateBelongsToThisMonth
         workContainerVStackView.isHidden = !dateBelongsToThisMonth
         
-        let displayCount = 4
+        workContainerVStackView.alpha = 0.0
+        
         switch calendarMode {
         case .personal:
-            workContainerVStackView.updatePersonalModeWorkRows(workList: workList, displayCount: displayCount)
+            workContainerVStackView.updatePersonalModeWorkRows(workList: workList)
         case .shared:
-            workContainerVStackView.updateSharedModeWorkRows(workList: workList, displayCount: displayCount)
+            workContainerVStackView.updateSharedModeWorkRows(workList: workList)
         }
         
         setNeedsLayout()

--- a/MOUP/MOUP/Presentation/Calendar/View/Components/WorkContainerVStackView.swift
+++ b/MOUP/MOUP/Presentation/Calendar/View/Components/WorkContainerVStackView.swift
@@ -40,13 +40,15 @@ final class WorkContainerVStackView: UIStackView {
     /// - Parameters:
     ///   - workList: 근무 Entity 배열 `[WorkSummary]`
     ///   - displayCount: 표시할 근무 UI 개수 `Int`
-    func updatePersonalModeWorkRows(workList: [WorkSummary], displayCount: Int) {
+    func updatePersonalModeWorkRows(workList: [WorkSummary]) {
         self.arrangedSubviews.forEach { $0.isHidden = true }
         
+        var displayedCount = 0
         for (index, work) in workList.enumerated() {
-            if index < displayCount {
+            if index < personalModeWorkRows.count {
                 personalModeWorkRows[index].update(work: work)
                 personalModeWorkRows[index].isHidden = false
+                displayedCount += 1
             } else {
                 break
             }
@@ -58,20 +60,22 @@ final class WorkContainerVStackView: UIStackView {
             personalModeWorkRows.forEach { $0.reduceSize() }
         }
         
-        showRestWorkCountRowIfRemain(displayedCount: displayCount)
+        showRestWorkCountRowIfRemain(displayedCount: displayedCount)
     }
     
     /// 공유 캘린더 모드일 때 근무 표시 UI를 업데이트하는 메서드
     /// - Parameters:
     ///   - workList: 근무 Entity 배열 `[WorkSummary]`
     ///   - displayCount: 표시할 근무 UI 개수 `Int`
-    func updateSharedModeWorkRows(workList: [WorkSummary], displayCount: Int) {
+    func updateSharedModeWorkRows(workList: [WorkSummary]) {
         self.arrangedSubviews.forEach { $0.isHidden = true }
         
+        var displayedCount = 0
         for (index, work) in workList.enumerated() {
-            if index < displayCount {
+            if index < sharedModeWorkRows.count {
                 sharedModeWorkRows[index].update(work: work)
                 sharedModeWorkRows[index].isHidden = false
+                displayedCount += 1
             } else {
                 break
             }
@@ -79,7 +83,7 @@ final class WorkContainerVStackView: UIStackView {
         
         workListCount = workList.count
         
-        showRestWorkCountRowIfRemain(displayedCount: displayCount)
+        showRestWorkCountRowIfRemain(displayedCount: displayedCount)
     }
     
     /// `CalendarDayCell`이 공간 부족일 경우 UI 중 일부를 숨김 처리하는 메서드

--- a/MOUP/MOUP/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/MOUP/MOUP/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -256,7 +256,6 @@ private extension CalendarViewController {
                     isToday: isToday,
                     daysOfWeek: cellState.day,
                     dateBelongsToThisMonth: dateBelongsToThisMonth,
-                    isSelected: isSelected,
                     calendarMode: calendarMode,
                     workList: workList)
     }
@@ -343,13 +342,13 @@ extension CalendarViewController: JTACMonthViewDelegate {
     
     func calendar(_ calendar: JTACMonthView, didSelectDate date: Date, cell: JTACDayCell?, cellState: CellState, indexPath: IndexPath) {
         selectedDate = date
-        configureCell(cell: cell, cellState: cellState, calendarMode: calendarModeRelay.value, workSet: calendarWorkDataSourceRelay.value[date] ?? [])
+        cell?.isSelected = true
         didSelectCell(selectedDate: date)
     }
     
     func calendar(_ calendar: JTACMonthView, didDeselectDate date: Date, cell: JTACDayCell?, cellState: CellState, indexPath: IndexPath) {
         selectedDate = nil
-        configureCell(cell: cell, cellState: cellState, calendarMode: calendarModeRelay.value, workSet: calendarWorkDataSourceRelay.value[date] ?? [])
+        cell?.isSelected = false
         didDeselectCell()
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #104 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
기존에 `systemLayoutSizeFitting`을 사용했을 땐 처음 캘린더 탭에 들어왔을 때 근무 UI가 의도대로 조절되지 않고 레이아웃을 벗어나는 문제가 있었습니다. 이를 `DispatchQueue.main.async`로 변경하여 근무 UI와 관련된 레이아웃이 계산된 뒤에 UI 크기를 조절하도록 변경하여 코드를 간소화하였습니다.
> 아직 근무를 삭제할 때 짧은 시간동안 레이아웃이 깨지는 현상이 있습니다. 추후 수정하겠습니다.

<br>

### 11/18 추가
크기 조절이 필요한 근무 UI인 경우 애니메이션을 추가하여 레이아웃이 깨지는 현상을 최대한 가리도록 수정했습니다.

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 근무 UI<br>애니메이션 | <img src = "https://github.com/user-attachments/assets/ed2c0c59-7b6e-47a8-ab08-ce147881e378" width ="250"> |

<br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |    구현 내용    |   스크린샷   |
| :-------------: | :----------: | :----------: | :----------: |
| 캘린더 근무 삭제 | <img src = "https://github.com/user-attachments/assets/d5364293-6555-4aaa-abfe-c918c784465a" width ="250"> | 캘린더 근무 추가 | <img src = "https://github.com/user-attachments/assets/6da28a2f-20cc-440b-bf5a-d221e804f540" width ="250"> |

<br>
