### PR TITLE
닉네임 설정 화면에서 기본 내비바 숨김 처리

### DIFF
--- a/MOUP/MOUP/Coordinator/Auth/SignUpCoordinator.swift
+++ b/MOUP/MOUP/Coordinator/Auth/SignUpCoordinator.swift
@@ -39,6 +39,7 @@ final class SignUpCoordinator: Coordinator {
         let nicknameViewController = NicknameViewController(nicknameViewModel: nicknameViewModel)
         nicknameViewController.coordinator = self
         let nav = UINavigationController(rootViewController: nicknameViewController)
+        nav.setNavigationBarHidden(true, animated: false)
         self.navigationController = nav
         DispatchQueue.main.async {
             UIView.transition(with: self.window, duration: 0.3, options: [.transitionCrossDissolve]) {

--- a/MOUP/MOUP/Coordinator/Auth/SignUpCoordinator.swift
+++ b/MOUP/MOUP/Coordinator/Auth/SignUpCoordinator.swift
@@ -8,7 +8,7 @@
 import UIKit
 import RxSwift
 
-final class SignUpCoordinator: Coordinator {
+final class SignUpCoordinator: NSObject, Coordinator {
     weak var signInCoordinator: SignInCoordinator?
     private var navigationController: UINavigationController?
     let window: UIWindow
@@ -40,6 +40,7 @@ final class SignUpCoordinator: Coordinator {
         nicknameViewController.coordinator = self
         let nav = UINavigationController(rootViewController: nicknameViewController)
         nav.setNavigationBarHidden(true, animated: false)
+        nav.interactivePopGestureRecognizer?.delegate = self
         self.navigationController = nav
         DispatchQueue.main.async {
             UIView.transition(with: self.window, duration: 0.3, options: [.transitionCrossDissolve]) {
@@ -84,5 +85,11 @@ final class SignUpCoordinator: Coordinator {
     func didFinishSignUp() {
         print("didFinishSignUp")
         signInCoordinator?.moveToTabBar()
+    }
+}
+
+extension SignUpCoordinator: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return (navigationController?.viewControllers.count ?? 0) > 1
     }
 }

--- a/MOUP/MOUP/Presentation/Auth/SignUp/View/NicknameView.swift
+++ b/MOUP/MOUP/Presentation/Auth/SignUp/View/NicknameView.swift
@@ -130,7 +130,7 @@ private extension NicknameView {
         }
         
         nicknameTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(navigationBar.snp.bottom).inset(32)
+            $0.top.equalTo(navigationBar.snp.bottom).offset(32)
             $0.directionalHorizontalEdges.equalToSuperview().inset(16)
         }
         


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #111 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- '닉네임 설정' 타이틀이 기본 내비게이션바에 밀려서 발생한 레이아웃 오류 수정했습니다.

<br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 닉네임 설정 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/a603ed86-28b6-4d5f-922a-e79bb6b73a98" /> |


<br>
