### PR TITLE
task: @SNMac 입력 폼 공통 UI 컴포넌트 구현

### DIFF
--- a/MOUP/MOUP/Presentation/InputForm/Components/LabelChevronRowView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/LabelChevronRowView.swift
@@ -6,3 +6,60 @@
 //
 
 import SwiftUI
+
+/// (색상)-라벨-Chevron-(라벨) Row
+struct LabelChevronRowView: View {
+    
+    // MARK: - Properties
+    private let color: UIColor?
+    private let frontLabel: String
+    private let rearLabel: String?
+    private let onTapAction: () -> Void
+    
+    // MARK: - Initializer
+    init(
+        color: UIColor? = nil,
+        frontLabel: String,
+        rearLabel: String? = nil,
+        onTapAction: @escaping () -> Void = {}
+    ) {
+        self.color = color
+        self.frontLabel = frontLabel
+        self.rearLabel = rearLabel
+        self.onTapAction = onTapAction
+    }
+    
+    // MARK: - Content
+    var body: some View {
+        Button(action: onTapAction) {
+            HStack(spacing: 12) {
+                if let color {
+                    Circle()
+                        .fill(Color(uiColor: color))
+                        .frame(width: 12, height: 12)
+                }
+                Text(frontLabel)
+                    .font(.bodyMedium(16))
+                
+                Spacer()
+                
+                if let rearLabel {
+                    Text(rearLabel)
+                        .font(.fieldsRegular(16))
+                }
+                Image(.chevronRight)
+            }
+            .padding(.horizontal, 16)
+            .contentShape(Rectangle())
+        }
+        .frame(height: 48)
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Preview
+#Preview {
+    LabelChevronRowView(color: .labelRed,
+                        frontLabel: "루틴 추가",
+                        rearLabel: "+ 1")
+}

--- a/MOUP/MOUP/Presentation/InputForm/Components/LabelChevronRowView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/LabelChevronRowView.swift
@@ -9,20 +9,19 @@ import SwiftUI
 
 /// (색상)-라벨-Chevron-(라벨) Row
 ///
-/// 옵션으로 좌측에 색상을 나타내는 원(`Circle`)을 띄우거나, 우측에 부가적인 텍스트(`rearLabel`)를 배치할 수 있습니다.
-/// 뷰 전체가 하나의 버튼으로 동작하므로, 터치 시 `onTapAction` 클로저를 통해 네비게이션 이동 등의 이벤트를 처리하기 좋습니다.
+/// 옵션으로 좌측에 색상을 나타내는 원(`leftColor`)을 띄우거나, 우측에 부가적인 텍스트(`rearLabel`)를 배치할 수 있습니다.
+/// 뷰 전체가 하나의 버튼으로 동작하므로, 터치 시 `action` 클로저를 통해 네비게이션 이동 등의 이벤트를 처리하기 좋습니다.
 ///
 /// **사용 예시:**
 /// ```swift
 /// struct ParentView: View {
 ///     var body: some View {
 ///         LabelChevronRowView(
-///             color: .systemRed,
 ///             frontLabel: "루틴 추가",
 ///             rearLabel: "+ 1",
-///             onTapAction: {
+///             action: {
 ///                 // 다른 화면으로 이동하거나 특정 로직을 실행합니다.
-///                 print("루틴 추가 Row가 탭 되었습니다!")
+///                 print("루틴 추가 Row 탭")
 ///             }
 ///         )
 ///     }
@@ -31,39 +30,39 @@ import SwiftUI
 struct LabelChevronRowView: View {
     
     // MARK: - Properties
-    private let color: UIColor?
+    private let leftColor: UIColor?
     private let frontLabel: String
     private let rearLabel: String?
-    private let onTapAction: () -> Void
+    private let action: () -> Void
     
     // MARK: - Initializer
     
     /// 새로운 `LabelChevronRowView`를 생성합니다.
     ///
     /// - Parameters:
-    ///   - color: 맨 좌측에 표시될 원형 마커의 색상(`UIColor`)입니다. `nil`일 경우 원이 표시되지 않습니다. 기본값은 `nil`입니다.
+    ///   - leftColor: 맨 좌측에 표시될 원형 마커의 색상(`UIColor`)입니다. `nil`일 경우 원이 표시되지 않습니다. 기본값은 `nil`입니다.
     ///   - frontLabel: 좌측에 표시될 메인 텍스트입니다.
     ///   - rearLabel: 우측 꺾쇠 아이콘 바로 앞에 표시될 부가 텍스트입니다. `nil`일 경우 표시되지 않습니다. 기본값은 `nil`입니다.
-    ///   - onTapAction: 행(Row) 전체를 탭 했을 때 실행될 액션 클로저입니다.
+    ///   - action: 행(Row) 전체를 탭 했을 때 실행될 액션 클로저입니다.
     init(
         color: UIColor? = nil,
         frontLabel: String,
         rearLabel: String? = nil,
-        onTapAction: @escaping () -> Void = {}
+        action: @escaping () -> Void = {}
     ) {
-        self.color = color
+        self.leftColor = color
         self.frontLabel = frontLabel
         self.rearLabel = rearLabel
-        self.onTapAction = onTapAction
+        self.action = action
     }
     
     // MARK: - Content
     var body: some View {
-        Button(action: onTapAction) {
+        Button(action: action) {
             HStack(spacing: 12) {
-                if let color {
+                if let leftColor {
                     Circle()
-                        .fill(Color(uiColor: color))
+                        .fill(Color(uiColor: leftColor))
                         .frame(width: 12, height: 12)
                 }
                 Text(frontLabel)
@@ -91,7 +90,7 @@ struct LabelChevronRowView: View {
 // MARK: - Preview
 #Preview {
     VStack(spacing: 0) {
-        // 색상과 부가 라벨이 모두 있는 경우
+        // 색상과 우측 라벨이 모두 있는 경우
         LabelChevronRowView(
             color: .labelRed,
             frontLabel: "빨간색"

--- a/MOUP/MOUP/Presentation/InputForm/Components/LabelChevronRowView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/LabelChevronRowView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// (색상)-라벨-Chevron-(라벨) Row
 ///
-/// 옵션으로 좌측에 색상을 나타내는 원(`leftColor`)을 띄우거나, 우측에 부가적인 텍스트(`rearLabel`)를 배치할 수 있습니다.
+/// 옵션으로 좌측에 색상을 나타내는 원(`leftColor`)을 띄우거나, 우측에 부가적인 텍스트(`rightLabel`)를 배치할 수 있습니다.
 /// 뷰 전체가 하나의 버튼으로 동작하므로, 터치 시 `action` 클로저를 통해 네비게이션 이동 등의 이벤트를 처리하기 좋습니다.
 ///
 /// **사용 예시:**
@@ -17,8 +17,8 @@ import SwiftUI
 /// struct ParentView: View {
 ///     var body: some View {
 ///         LabelChevronRowView(
-///             frontLabel: "루틴 추가",
-///             rearLabel: "+ 1",
+///             titleLabel: "루틴 추가",
+///             rightLabel: "+ 1",
 ///             action: {
 ///                 // 다른 화면으로 이동하거나 특정 로직을 실행합니다.
 ///                 print("루틴 추가 Row 탭")
@@ -31,8 +31,8 @@ struct LabelChevronRowView: View {
     
     // MARK: - Properties
     private let leftColor: UIColor?
-    private let frontLabel: String
-    private let rearLabel: String?
+    private let titleLabel: String
+    private let rightLabel: String?
     private let action: () -> Void
     
     // MARK: - Initializer
@@ -41,18 +41,18 @@ struct LabelChevronRowView: View {
     ///
     /// - Parameters:
     ///   - leftColor: 맨 좌측에 표시될 원형 마커의 색상(`UIColor`)입니다. `nil`일 경우 원이 표시되지 않습니다. 기본값은 `nil`입니다.
-    ///   - frontLabel: 좌측에 표시될 메인 텍스트입니다.
-    ///   - rearLabel: 우측 꺾쇠 아이콘 바로 앞에 표시될 부가 텍스트입니다. `nil`일 경우 표시되지 않습니다. 기본값은 `nil`입니다.
+    ///   - titleLabel: 좌측에 표시될 메인 텍스트입니다.
+    ///   - rightLabel: 우측 꺾쇠 아이콘 바로 앞에 표시될 부가 텍스트입니다. `nil`일 경우 표시되지 않습니다. 기본값은 `nil`입니다.
     ///   - action: 행(Row) 전체를 탭 했을 때 실행될 액션 클로저입니다.
     init(
-        color: UIColor? = nil,
-        frontLabel: String,
-        rearLabel: String? = nil,
+        leftColor: UIColor? = nil,
+        titleLabel: String,
+        rightLabel: String? = nil,
         action: @escaping () -> Void = {}
     ) {
-        self.leftColor = color
-        self.frontLabel = frontLabel
-        self.rearLabel = rearLabel
+        self.leftColor = leftColor
+        self.titleLabel = titleLabel
+        self.rightLabel = rightLabel
         self.action = action
     }
     
@@ -65,14 +65,14 @@ struct LabelChevronRowView: View {
                         .fill(Color(uiColor: leftColor))
                         .frame(width: 12, height: 12)
                 }
-                Text(frontLabel)
+                Text(titleLabel)
                     .font(.bodyMedium(16))
                     .foregroundStyle(.gray900)
                 
                 Spacer()
                 
-                if let rearLabel {
-                    Text(rearLabel)
+                if let rightLabel {
+                    Text(rightLabel)
                         .font(.fieldsRegular(16))
                         .foregroundStyle(.gray900)
                 }
@@ -90,16 +90,16 @@ struct LabelChevronRowView: View {
 // MARK: - Preview
 #Preview {
     VStack(spacing: 0) {
-        // 색상과 우측 라벨이 모두 있는 경우
+        // 색상과 메인 라벨이 있는 경우
         LabelChevronRowView(
-            color: .labelRed,
-            frontLabel: "빨간색"
+            leftColor: .labelRed,
+            titleLabel: "빨간색"
         )
         
-        // 메인 라벨만 있는 경우
+        // 메인 라벨과 우측 라벨이 있는 경우
         LabelChevronRowView(
-            frontLabel: "루틴 추가",
-            rearLabel: "+ 1"
+            titleLabel: "루틴 추가",
+            rightLabel: "+ 1"
         )
     }
 }

--- a/MOUP/MOUP/Presentation/InputForm/Components/LabelChevronRowView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/LabelChevronRowView.swift
@@ -8,6 +8,26 @@
 import SwiftUI
 
 /// (색상)-라벨-Chevron-(라벨) Row
+///
+/// 옵션으로 좌측에 색상을 나타내는 원(`Circle`)을 띄우거나, 우측에 부가적인 텍스트(`rearLabel`)를 배치할 수 있습니다.
+/// 뷰 전체가 하나의 버튼으로 동작하므로, 터치 시 `onTapAction` 클로저를 통해 네비게이션 이동 등의 이벤트를 처리하기 좋습니다.
+///
+/// **사용 예시:**
+/// ```swift
+/// struct ParentView: View {
+///     var body: some View {
+///         LabelChevronRowView(
+///             color: .systemRed,
+///             frontLabel: "루틴 추가",
+///             rearLabel: "+ 1",
+///             onTapAction: {
+///                 // 다른 화면으로 이동하거나 특정 로직을 실행합니다.
+///                 print("루틴 추가 Row가 탭 되었습니다!")
+///             }
+///         )
+///     }
+/// }
+/// ```
 struct LabelChevronRowView: View {
     
     // MARK: - Properties
@@ -17,6 +37,14 @@ struct LabelChevronRowView: View {
     private let onTapAction: () -> Void
     
     // MARK: - Initializer
+    
+    /// 새로운 `LabelChevronRowView`를 생성합니다.
+    ///
+    /// - Parameters:
+    ///   - color: 맨 좌측에 표시될 원형 마커의 색상(`UIColor`)입니다. `nil`일 경우 원이 표시되지 않습니다. 기본값은 `nil`입니다.
+    ///   - frontLabel: 좌측에 표시될 메인 텍스트입니다.
+    ///   - rearLabel: 우측 꺾쇠 아이콘 바로 앞에 표시될 부가 텍스트입니다. `nil`일 경우 표시되지 않습니다. 기본값은 `nil`입니다.
+    ///   - onTapAction: 행(Row) 전체를 탭 했을 때 실행될 액션 클로저입니다.
     init(
         color: UIColor? = nil,
         frontLabel: String,
@@ -40,16 +68,19 @@ struct LabelChevronRowView: View {
                 }
                 Text(frontLabel)
                     .font(.bodyMedium(16))
+                    .foregroundStyle(.gray900)
                 
                 Spacer()
                 
                 if let rearLabel {
                     Text(rearLabel)
                         .font(.fieldsRegular(16))
+                        .foregroundStyle(.gray900)
                 }
                 Image(.chevronRight)
             }
             .padding(.horizontal, 16)
+            .padding(.vertical, 12)
             .contentShape(Rectangle())
         }
         .frame(height: 48)
@@ -59,7 +90,17 @@ struct LabelChevronRowView: View {
 
 // MARK: - Preview
 #Preview {
-    LabelChevronRowView(color: .labelRed,
-                        frontLabel: "루틴 추가",
-                        rearLabel: "+ 1")
+    VStack(spacing: 0) {
+        // 색상과 부가 라벨이 모두 있는 경우
+        LabelChevronRowView(
+            color: .labelRed,
+            frontLabel: "빨간색"
+        )
+        
+        // 메인 라벨만 있는 경우
+        LabelChevronRowView(
+            frontLabel: "루틴 추가",
+            rearLabel: "+ 1"
+        )
+    }
 }

--- a/MOUP/MOUP/Presentation/InputForm/Components/LabelChevronRowView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/LabelChevronRowView.swift
@@ -78,8 +78,8 @@ struct LabelChevronRowView: View {
                 }
                 Image(.chevronRight)
             }
-            .padding(.horizontal, 16)
             .padding(.vertical, 12)
+            .padding(.horizontal, 16)
             .contentShape(Rectangle())
         }
         .frame(height: 48)

--- a/MOUP/MOUP/Presentation/InputForm/Components/MemoView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/MemoView.swift
@@ -53,10 +53,10 @@ struct MemoView: View {
         .foregroundStyle(.gray900)
         .setLineSpacing(.fieldsRegular, fontSize: 16)
         .focused($isFocused)
-        .frame(minHeight: 156, alignment: .topLeading)
         .padding(.top, 16)
         .padding(.horizontal, 16)
         .padding(.bottom, 40)
+        .frame(minHeight: 156, alignment: .topLeading)
         .onChange(of: text) { newValue in // Deprecated 예정, iOS 17부터 onChange(of:initial:_:)로 변경
             guard newValue.count > maxCount else { return }
             text = String(newValue.prefix(maxCount))

--- a/MOUP/MOUP/Presentation/InputForm/Components/MemoView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/MemoView.swift
@@ -1,0 +1,98 @@
+//
+//  MemoView.swift
+//  MOUP
+//
+//  Created by 서동환 on 3/5/26.
+//
+
+import SwiftUI
+
+/// 메모 필드
+///
+/// 사용자가 긴 문장을 작성할 때 위에서 아래로 늘어나며 입력할 수 있도록 구성되어 있습니다.
+/// 내부적으로 최대 150자의 글자 수 제한 기능을 포함하고 있으며, 우측 하단에 글자 수 카운터를 표시합니다.
+///
+/// **사용 예시:**
+/// ```swift
+/// struct ParentView: View {
+///     @State private var memo = ""
+///
+///     var body: some View {
+///         MemoView(text: $memo)
+///     }
+/// }
+/// ```
+struct MemoView: View {
+    
+    // MARK: - Properties
+    private let maxCount = 150
+    
+    @Binding private var text: String
+    @FocusState private var isFocused: Bool
+    
+    // MARK: - Initializer
+    
+    /// 새로운 `MemoView`를 생성합니다.
+    ///
+    /// - Parameter text: 부모 뷰와 연결되어 텍스트를 양방향으로 공유할 문자열 바인딩(`@Binding`)입니다.
+    init(text: Binding<String>) {
+        self._text = text
+    }
+    
+    // MARK: - Content
+    var body: some View {
+        TextField(
+            "",
+            text: $text,
+            prompt: Text("추가적인 내용을 입력해주세요")
+                .font(.fieldsRegular(16))
+                .foregroundColor(.gray400), // Deprecated 예정, iOS 17부터 foregroundStyle로 변경
+            axis: .vertical
+        )
+        .font(.fieldsRegular(16))
+        .foregroundStyle(.gray900)
+        .setLineSpacing(.fieldsRegular, fontSize: 16)
+        .focused($isFocused)
+        .frame(minHeight: 156, alignment: .topLeading)
+        .padding(.top, 16)
+        .padding(.horizontal, 16)
+        .padding(.bottom, 40)
+        .onChange(of: text) { newValue in // Deprecated 예정, iOS 17부터 onChange(of:initial:_:)로 변경
+            guard newValue.count > maxCount else { return }
+            text = String(newValue.prefix(maxCount))
+        }
+        .overlay(alignment: .bottomTrailing) {
+            Text("\(text.count)/\(maxCount)")
+                .font(.fieldsRegular(16))
+                .foregroundColor(.gray600)
+                .padding(.bottom, 12)
+                .padding(.trailing, 16)
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(.gray400, lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            isFocused = true
+        }
+    }
+}
+
+// MARK: - Preview
+private struct MemoPreviewWrapper: View {
+    @State private var text1 = ""
+    @State private var text2 = "텍스트 입력 상황"
+    
+    var body: some View {
+        VStack(spacing: 12) {
+            MemoView(text: $text1)
+            MemoView(text: $text2)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    MemoPreviewWrapper()
+}

--- a/MOUP/MOUP/Presentation/InputForm/Components/RadioButtonView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/RadioButtonView.swift
@@ -1,0 +1,130 @@
+//
+//  RadioButtonView.swift
+//  MOUP
+//
+//  Created by 서동환 on 3/5/26.
+//
+
+import SwiftUI
+
+/// 라디오버튼 (라벨only, 이미지-라벨)
+///
+/// 이 뷰는 내부적으로 상태를 가지지 않으며(`@State` 없음), 외부에서 주입받은 `isSelected` 값에 따라
+/// 폰트 굵기, 좌측 아이콘(선택/미선택), 우측 라디오 아이콘, 테두리 색상 등의 UI를 자동으로 업데이트합니다.
+///
+/// **사용 예시:**
+/// ```swift
+/// struct ParentView: View {
+///     @State private var selectedOption = "음식점"
+///
+///     var body: some View {
+///         RadioButtonView(
+///             unselectedImage: .restaurantUnselected,
+///             selectedImage: .restaurantSelected,
+///             label: "음식점",
+///             isSelected: selectedOption == "음식점",
+///             onTapAction: {
+///                 // 탭 되었을 때 부모 뷰의 상태를 업데이트합니다.
+///                 selectedOption = "음식점"
+///                 print("음식점 버튼이 눌렸습니다!")
+///             }
+///         )
+///     }
+/// }
+/// ```
+struct RadioButtonView: View {
+    
+    // MARK: - Properties
+    private let unselectedImage: UIImage?
+    private let selectedImage: UIImage?
+    private let label: String
+    private let isSelected: Bool
+    private let onTapAction: () -> Void
+    
+    // MARK: - Initializer
+    
+    /// 새로운 `RadioButtonView`를 생성합니다.
+    /// - Parameters:
+    ///   - unselectedImage: 버튼이 선택되지 않았을 때 좌측에 표시될 옵셔널 이미지입니다. (기본값 `nil`)
+    ///   - selectedImage: 버튼이 선택되었을 때 좌측에 표시될 옵셔널 이미지입니다. (기본값 `nil`)
+    ///   - label: 라디오 버튼에 표시될 텍스트입니다.
+    ///   - isSelected: 버튼의 선택 여부를 결정하는 불리언 값입니다. `true`일 경우 선택 상태 UI가 표시됩니다. 기본값은 `false`입니다.
+    ///   - onTapAction: 버튼이 탭 되었을 때 실행될 클로저입니다. 이 클로저 내부에서 부모 뷰의 상태 값을 변경해야 합니다.
+    init(
+        unselectedImage: UIImage? = nil,
+        selectedImage: UIImage? = nil,
+        label: String,
+        isSelected: Bool = false,
+        onTapAction: @escaping () -> Void = {}
+    ) {
+        self.unselectedImage = unselectedImage
+        self.selectedImage = selectedImage
+        self.label = label
+        self.isSelected = isSelected
+        self.onTapAction = onTapAction
+    }
+    
+    // MARK: - Content
+    var body: some View {
+        Button(action: onTapAction) {
+            HStack(spacing: 12) {
+                if isSelected {
+                    if let selectedImage {
+                        Image(uiImage: selectedImage)
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                    }
+                } else {
+                    if let unselectedImage {
+                        Image(uiImage: unselectedImage)
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                    }
+                }
+                Text(label)
+                    .font(isSelected ? .headBold(16) : .bodyMedium(16))
+                    .foregroundStyle(isSelected ? .accent : .gray900)
+                
+                Spacer()
+                
+                if isSelected {
+                    Image(.radioSelected)
+                } else {
+                    Image(.radioUnselected)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isSelected ? .accent : .gray400,
+                        lineWidth: isSelected ? 2.0 : 1.0)
+        )
+        .frame(height: 48)
+    }
+}
+
+// MARK: - Preview
+#Preview {
+    VStack(spacing: 12) {
+        // 미선택 상태
+        RadioButtonView(
+            unselectedImage: .restaurantUnselected,
+            selectedImage: .restaurantSelected,
+            label: "음식점",
+            isSelected: false,
+        )
+        
+        // 선택 상태
+        RadioButtonView(
+            unselectedImage: .cafeUnselected,
+            selectedImage: .cafeSelected,
+            label: "카페",
+            isSelected: true,
+        )
+    }
+    .padding()
+}

--- a/MOUP/MOUP/Presentation/InputForm/Components/RadioButtonView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/RadioButtonView.swift
@@ -68,18 +68,10 @@ struct RadioButtonView: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 12) {
-                if isSelected {
-                    if let selectedLeftImage {
-                        Image(uiImage: selectedLeftImage)
-                            .resizable()
-                            .frame(width: 24, height: 24)
-                    }
-                } else {
-                    if let unselectedLeftImage {
-                        Image(uiImage: unselectedLeftImage)
-                            .resizable()
-                            .frame(width: 24, height: 24)
-                    }
+                if let image = isSelected ? selectedLeftImage : unselectedLeftImage {
+                    Image(uiImage: image)
+                        .resizable()
+                        .frame(width: 24, height: 24)
                 }
                 Text(label)
                     .font(isSelected ? .headBold(16) : .bodyMedium(16))
@@ -93,8 +85,8 @@ struct RadioButtonView: View {
                     Image(.radioUnselected)
                 }
             }
-            .padding(.horizontal, 16)
             .padding(.vertical, 12)
+            .padding(.horizontal, 16)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/MOUP/MOUP/Presentation/InputForm/Components/RadioButtonView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/RadioButtonView.swift
@@ -99,7 +99,7 @@ struct RadioButtonView: View {
         }
         .buttonStyle(.plain)
         .overlay(
-            RoundedRectangle(cornerRadius: 8)
+            RoundedRectangle(cornerRadius: 12)
                 .stroke(isSelected ? .accent : .gray400,
                         lineWidth: isSelected ? 2.0 : 1.0)
         )

--- a/MOUP/MOUP/Presentation/InputForm/Components/RadioButtonView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/RadioButtonView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// 라디오버튼 (라벨only, 이미지-라벨)
 ///
 /// 이 뷰는 내부적으로 상태를 가지지 않으며(`@State` 없음), 외부에서 주입받은 `isSelected` 값에 따라
-/// 폰트 굵기, 좌측 아이콘(선택/미선택), 우측 라디오 아이콘, 테두리 색상 등의 UI를 자동으로 업데이트합니다.
+/// 폰트 굵기, 좌측 아이콘(선택/미선택), 우측 라디오 아이콘, 테두리 색상 등의 UI를 업데이트합니다.
 ///
 /// **사용 예시:**
 /// ```swift
@@ -19,14 +19,14 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         RadioButtonView(
-///             unselectedImage: .restaurantUnselected,
-///             selectedImage: .restaurantSelected,
+///             unselectedLeftImage: .restaurantUnselected,
+///             selectedLeftImage: .restaurantSelected,
 ///             label: "음식점",
 ///             isSelected: selectedOption == "음식점",
-///             onTapAction: {
+///             action: {
 ///                 // 탭 되었을 때 부모 뷰의 상태를 업데이트합니다.
 ///                 selectedOption = "음식점"
-///                 print("음식점 버튼이 눌렸습니다!")
+///                 print("음식점 버튼 탭")
 ///             }
 ///         )
 ///     }
@@ -35,48 +35,48 @@ import SwiftUI
 struct RadioButtonView: View {
     
     // MARK: - Properties
-    private let unselectedImage: UIImage?
-    private let selectedImage: UIImage?
+    private let unselectedLeftImage: UIImage?
+    private let selectedLeftImage: UIImage?
     private let label: String
     private let isSelected: Bool
-    private let onTapAction: () -> Void
+    private let action: () -> Void
     
     // MARK: - Initializer
     
     /// 새로운 `RadioButtonView`를 생성합니다.
     /// - Parameters:
-    ///   - unselectedImage: 버튼이 선택되지 않았을 때 좌측에 표시될 옵셔널 이미지입니다. (기본값 `nil`)
-    ///   - selectedImage: 버튼이 선택되었을 때 좌측에 표시될 옵셔널 이미지입니다. (기본값 `nil`)
+    ///   - unselectedLeftImage: 버튼이 선택되지 않았을 때 좌측에 표시될 옵셔널 이미지입니다. (기본값 `nil`)
+    ///   - selectedLeftImage: 버튼이 선택되었을 때 좌측에 표시될 옵셔널 이미지입니다. (기본값 `nil`)
     ///   - label: 라디오 버튼에 표시될 텍스트입니다.
     ///   - isSelected: 버튼의 선택 여부를 결정하는 불리언 값입니다. `true`일 경우 선택 상태 UI가 표시됩니다. 기본값은 `false`입니다.
-    ///   - onTapAction: 버튼이 탭 되었을 때 실행될 클로저입니다. 이 클로저 내부에서 부모 뷰의 상태 값을 변경해야 합니다.
+    ///   - action: 버튼이 탭 되었을 때 실행될 클로저입니다. 이 클로저 내부에서 부모 뷰의 상태 값을 변경해야 합니다.
     init(
-        unselectedImage: UIImage? = nil,
-        selectedImage: UIImage? = nil,
+        unselectedLeftImage: UIImage? = nil,
+        selectedLeftImage: UIImage? = nil,
         label: String,
         isSelected: Bool = false,
-        onTapAction: @escaping () -> Void = {}
+        action: @escaping () -> Void = {}
     ) {
-        self.unselectedImage = unselectedImage
-        self.selectedImage = selectedImage
+        self.unselectedLeftImage = unselectedLeftImage
+        self.selectedLeftImage = selectedLeftImage
         self.label = label
         self.isSelected = isSelected
-        self.onTapAction = onTapAction
+        self.action = action
     }
     
     // MARK: - Content
     var body: some View {
-        Button(action: onTapAction) {
+        Button(action: action) {
             HStack(spacing: 12) {
                 if isSelected {
-                    if let selectedImage {
-                        Image(uiImage: selectedImage)
+                    if let selectedLeftImage {
+                        Image(uiImage: selectedLeftImage)
                             .resizable()
                             .frame(width: 24, height: 24)
                     }
                 } else {
-                    if let unselectedImage {
-                        Image(uiImage: unselectedImage)
+                    if let unselectedLeftImage {
+                        Image(uiImage: unselectedLeftImage)
                             .resizable()
                             .frame(width: 24, height: 24)
                     }
@@ -101,7 +101,7 @@ struct RadioButtonView: View {
         .overlay(
             RoundedRectangle(cornerRadius: 12)
                 .stroke(isSelected ? .accent : .gray400,
-                        lineWidth: isSelected ? 2.0 : 1.0)
+                        lineWidth: isSelected ? 2 : 1)
         )
         .frame(height: 48)
     }
@@ -112,16 +112,16 @@ struct RadioButtonView: View {
     VStack(spacing: 12) {
         // 미선택 상태
         RadioButtonView(
-            unselectedImage: .restaurantUnselected,
-            selectedImage: .restaurantSelected,
+            unselectedLeftImage: .restaurantUnselected,
+            selectedLeftImage: .restaurantSelected,
             label: "음식점",
             isSelected: false,
         )
         
         // 선택 상태
         RadioButtonView(
-            unselectedImage: .cafeUnselected,
-            selectedImage: .cafeSelected,
+            unselectedLeftImage: .cafeUnselected,
+            selectedLeftImage: .cafeSelected,
             label: "카페",
             isSelected: true,
         )

--- a/MOUP/MOUP/Presentation/InputForm/Components/WizardTextFieldView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/WizardTextFieldView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// 입력 폼의 내부 네비게이션에서 사용되는 텍스트 입력 필드
+/// 텍스트 입력 필드 (내부 네비게이션에서 사용)
 ///
 /// 내부적으로 `@Binding`을 사용하여 부모 뷰와 텍스트 상태를 양방향으로 공유하며,
 /// 지정된 정규표현식(Regex)을 활용하여 허용되지 않은 문자(예: 문자, 기호) 입력을 차단합니다.
@@ -90,38 +90,45 @@ struct WizardTextFieldView: View {
     // MARK: - Content
     var body: some View {
         HStack {
-            TextField(placeholder, text: $text)
-                .font(.fieldsRegular(16))
-                .focused($isFocused)
-                .lineLimit(1)
-                .keyboardType(keyboardType)
-                .onChange(of: text) { newValue in
-                    guard !newValue.isEmpty else {
-                        lastValidText = newValue
-                        return
-                    }
-                    
-                    // 정규표현식 검사
-                    if let regex {
-                        do {
-                            let swiftRegex = try Regex(regex)
-                            guard newValue.wholeMatch(of: swiftRegex) != nil else {
-                                text = lastValidText
-                                return
-                            }
-                        } catch {
-                            assertionFailure("올바르지 않은 정규표현식입니다: \(regex)")
-                        }
-                    }
-                    
+            TextField(
+                "",
+                text: $text,
+                prompt: Text(placeholder)
+                    .font(.fieldsRegular(16))
+                    .foregroundColor(.gray400) // Deprecated 예정, iOS 17부터 foregroundStyle로 변경
+            )
+            .font(.fieldsRegular(16))
+            .foregroundStyle(.gray900)
+            .focused($isFocused)
+            .lineLimit(1)
+            .keyboardType(keyboardType)
+            .onChange(of: text) { newValue in // Deprecated 예정, iOS 17부터 onChange(of:initial:_:)로 변경
+                guard !newValue.isEmpty else {
                     lastValidText = newValue
+                    return
                 }
-                .onAppear {
-                    lastValidText = text
+                
+                // 정규표현식 검사
+                if let regex {
+                    do {
+                        let swiftRegex = try Regex(regex)
+                        guard newValue.wholeMatch(of: swiftRegex) != nil else {
+                            text = lastValidText
+                            return
+                        }
+                    } catch {
+                        assertionFailure("올바르지 않은 정규표현식입니다: \(regex)")
+                    }
                 }
+                
+                lastValidText = newValue
+            }
+            .onAppear {
+                lastValidText = text
+            }
         }
-        .padding(.horizontal, 16)
         .padding(.vertical, 12)
+        .padding(.horizontal, 16)
         .frame(height: 48)
         .overlay(
             RoundedRectangle(cornerRadius: 12)

--- a/MOUP/MOUP/Presentation/InputForm/Components/WizardTextFieldView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/WizardTextFieldView.swift
@@ -1,0 +1,170 @@
+//
+//  WizardTextFieldView.swift
+//  MOUP
+//
+//  Created by 서동환 on 3/5/26.
+//
+
+import SwiftUI
+
+/// 입력 폼의 내부 네비게이션에서 사용되는 텍스트 입력 필드
+///
+/// 내부적으로 `@Binding`을 사용하여 부모 뷰와 텍스트 상태를 양방향으로 공유하며,
+/// 지정된 정규표현식(Regex)을 활용하여 허용되지 않은 문자(예: 문자, 기호) 입력을 차단합니다.
+///
+/// **사용 예시 1: 일반 텍스트 입력**
+/// ```swift
+/// struct ParentView: View {
+///     @State private var workplaceName = ""
+///
+///     var body: some View {
+///         WizardTextFieldView(
+///             placeholder: "근무지 이름",
+///             text: $workplaceName
+///         )
+///     }
+/// }
+/// ```
+///
+/// **사용 예시 2: 금액 포매팅 (커스텀 바인딩 및 정규식 활용)**
+/// 부모 뷰는 순수 정수(`Int`)를 관리하고, 화면에는 콤마와 단위를 표시할 때 커스텀 바인딩을 사용합니다.
+/// ```swift
+/// struct SalaryInputView: View {
+///     @State private var salary = 15000
+///
+///     var body: some View {
+///         WizardTextFieldView(
+///             placeholder: "10,320원",
+///             text: Binding<String>(
+///                 get: {
+///                     // 부모 뷰의 순수 데이터를 포매팅하여 텍스트 필드에 표시
+///                     NumberFormatter.formattedWon(from: salary)
+///                 },
+///                 set: { newValue in
+///                     // 사용자가 입력한 값에서 숫자만 필터링하여 부모 변수에 저장
+///                     let numbersOnly = newValue.filter { $0.isNumber }
+///                     if let intValue = Int(numbersOnly) {
+///                         salary = intValue
+///                     }
+///                 }
+///             ),
+///             keyboardType: .numberPad,
+///             // 숫자, 콤마(,), '원' 글자만 입력 가능하도록 정규식 제한
+///             regex: "^[0-9,원]*$"
+///         )
+///     }
+/// }
+/// ```
+struct WizardTextFieldView: View {
+    
+    // MARK: - Properties
+    private let placeholder: String
+    private let keyboardType: UIKeyboardType
+    private let regex: String?
+    
+    @Binding private var text: String
+    @FocusState private var isFocused: Bool
+    @State private var lastValidText: String = ""
+    
+    // MARK: - Initializer
+    
+    /// 새로운 `WizardTextFieldView`를 생성합니다.
+    ///
+    /// - Parameters:
+    ///   - placeholder: 입력값이 없을 때 표시될 안내 문구입니다.
+    ///   - text: 부모 뷰와 연결된 문자열 바인딩(`@Binding`)입니다.
+    ///   - keyboardType: 텍스트 필드 포커스 시 표시될 키보드 타입입니다. 기본값은 `.default`입니다.
+    ///   - regex: 입력값을 제한할 정규표현식 문자열입니다. 기본값은 `nil`입니다.
+    init(
+        placeholder: String,
+        text: Binding<String>,
+        keyboardType: UIKeyboardType = .default,
+        regex: String? = nil
+    ) {
+        self.placeholder = placeholder
+        self._text = text
+        self.keyboardType = keyboardType
+        self.regex = regex
+    }
+    
+    // MARK: - Content
+    var body: some View {
+        HStack {
+            TextField(placeholder, text: $text)
+                .font(.fieldsRegular(16))
+                .focused($isFocused)
+                .lineLimit(1)
+                .keyboardType(keyboardType)
+                .onChange(of: text) { newValue in
+                    guard !newValue.isEmpty else {
+                        lastValidText = newValue
+                        return
+                    }
+                    
+                    // 정규표현식 검사
+                    if let regex {
+                        do {
+                            let swiftRegex = try Regex(regex)
+                            guard newValue.wholeMatch(of: swiftRegex) != nil else {
+                                text = lastValidText
+                                return
+                            }
+                        } catch {
+                            assertionFailure("올바르지 않은 정규표현식입니다: \(regex)")
+                        }
+                    }
+                    
+                    lastValidText = newValue
+                }
+                .onAppear {
+                    lastValidText = text
+                }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(height: 48)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(.gray400, lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Preview
+private struct WizardTextFieldPreviewWrapper: View {
+    @State private var workplaceName = ""
+    @State private var salary = 15000
+    
+    var body: some View {
+        VStack(spacing: 12) {
+            WizardTextFieldView(
+                placeholder: "근무지 이름",
+                text: $workplaceName
+            )
+            
+            WizardTextFieldView(
+                placeholder: "10,320원",
+                text: Binding<String>(
+                    get: {
+                        NumberFormatter.formattedWon(from: salary)
+                    },
+                    set: { newValue in
+                        let numbersOnly = newValue.filter { $0.isNumber }
+                        if let intValue = Int(numbersOnly) {
+                            salary = intValue
+                        }
+                    }
+                ),
+                keyboardType: .numberPad,
+                regex: "^[0-9,원]*$"
+            )
+            
+            Text("부모 뷰가 가진 원본 데이터: \(salary)")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    WizardTextFieldPreviewWrapper()
+}

--- a/MOUP/MOUP/Presentation/InputForm/Components/WizardTextFieldView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/WizardTextFieldView.swift
@@ -60,7 +60,7 @@ struct WizardTextFieldView: View {
     // MARK: - Properties
     private let placeholder: String
     private let keyboardType: UIKeyboardType
-    private let regex: String?
+    private let regex: Regex<AnyRegexOutput>?
     
     @Binding private var text: String
     @FocusState private var isFocused: Bool
@@ -79,12 +79,19 @@ struct WizardTextFieldView: View {
         placeholder: String,
         text: Binding<String>,
         keyboardType: UIKeyboardType = .default,
-        regex: String? = nil
+        regexStr: String? = nil
     ) {
         self.placeholder = placeholder
         self._text = text
         self.keyboardType = keyboardType
-        self.regex = regex
+        if let regexStr {
+            self.regex = try? Regex(regexStr)
+            assert(self.regex != nil, "올바르지 않은 정규표현식: \(regexStr)")
+        } else {
+            self.regex = nil
+        }
+        
+        self._lastValidText = State(initialValue: text.wrappedValue)
     }
     
     // MARK: - Content
@@ -110,14 +117,9 @@ struct WizardTextFieldView: View {
                 
                 // 정규표현식 검사
                 if let regex {
-                    do {
-                        let swiftRegex = try Regex(regex)
-                        guard newValue.wholeMatch(of: swiftRegex) != nil else {
-                            text = lastValidText
-                            return
-                        }
-                    } catch {
-                        assertionFailure("올바르지 않은 정규표현식입니다: \(regex)")
+                    guard newValue.wholeMatch(of: regex) != nil else {
+                        text = lastValidText
+                        return
                     }
                 }
                 
@@ -163,7 +165,7 @@ private struct WizardTextFieldPreviewWrapper: View {
                     }
                 ),
                 keyboardType: .numberPad,
-                regex: "^[0-9,원]*$"
+                regexStr: "^[0-9,원]*$"
             )
             
             Text("부모 뷰가 가진 원본 데이터: \(salary)")

--- a/MOUP/MOUP/Presentation/InputForm/Components/WizardTextFieldView.swift
+++ b/MOUP/MOUP/Presentation/InputForm/Components/WizardTextFieldView.swift
@@ -50,7 +50,7 @@ import SwiftUI
 ///             ),
 ///             keyboardType: .numberPad,
 ///             // 숫자, 콤마(,), '원' 글자만 입력 가능하도록 정규식 제한
-///             regex: "^[0-9,원]*$"
+///             regexStr: "^[0-9,원]*$"
 ///         )
 ///     }
 /// }
@@ -124,9 +124,6 @@ struct WizardTextFieldView: View {
                 }
                 
                 lastValidText = newValue
-            }
-            .onAppear {
-                lastValidText = text
             }
         }
         .padding(.vertical, 12)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #117 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
입력 폼 공통 UI 컴포넌트 일부 구현
- (색상)-라벨-Chevron-(라벨) Row
  - `LabelChevronRowView`
- 라디오버튼 (라벨only, 이미지-라벨)
  - `RadioButtonView`
- 텍스트 입력 필드 (내부 네비게이션에서 사용)
  - `WizardTextFieldView`
- 메모 필드
  - `MemoView`

사용법을 각 컴포넌트에 문서주석으로 남겨놓았습니다. 참고 부탁드립니다.

<br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| `LabelChevronRowView` | <img src = "https://github.com/user-attachments/assets/d6dfb923-54bc-479d-b3e0-1309583de835" width ="250"> |
| `RadioButtonView` | <img src = "https://github.com/user-attachments/assets/a9a13992-7a09-4738-b5ca-d605a3aa2a0d" width ="250"> |
| `WizardTextFieldView` | <img src = "https://github.com/user-attachments/assets/36ed71ab-1c81-43cc-9c38-2e6f3b087747" width ="250"> |
| `MemoView` | <img src = "https://github.com/user-attachments/assets/f0e7cb78-09e6-4742-aca2-ff93d6240d3c" width ="250"> |

<br>
